### PR TITLE
Bump PHP min version and add pestphp v4 as requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "filament/filament": "^4.0|^5.0",
         "nikic/php-parser": "^5.0",
         "symfony/console": "^6.0|^7.0"


### PR DESCRIPTION
## Add v4 pestphp version to dev requirement

Added PestPHP v4 support alongside v3 in `composer.json` dev dependencies (`^3.0|^4.0`).

## Min PHP version same as Filament

Bumped the minimum PHP version from `^8.1` to `^8.2` to match Filament's requirement.