### PR TITLE
Fix incorrect line numbers

### DIFF
--- a/bin/filacheck
+++ b/bin/filacheck
@@ -142,7 +142,7 @@ foreach ($registry->all() as $rule) {
     $scanner->addRule($rule);
 }
 
-$violations = $scanner->scan($path);
+$violations = $scanner->scan($path, getcwd());
 
 $hasBladeRules = array_filter($scanner->getRules(), fn ($rule) => $rule instanceof BladeRule);
 

--- a/src/Commands/FilacheckCommand.php
+++ b/src/Commands/FilacheckCommand.php
@@ -34,7 +34,7 @@ class FilacheckCommand extends Command
             $scanner->addRule($rule);
         }
 
-        $violations = $scanner->scan($path);
+        $violations = $scanner->scan($path, base_path());
 
         $hasBladeRules = array_filter($scanner->getRules(), fn ($rule) => $rule instanceof BladeRule);
 

--- a/src/Rules/Concerns/CalculatesLineNumbers.php
+++ b/src/Rules/Concerns/CalculatesLineNumbers.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Filacheck\Rules\Concerns;
+
+trait CalculatesLineNumbers
+{
+    /**
+     * Calculate accurate line number from file position by counting newlines.
+     */
+    protected function getLineFromPosition(string $code, int $position): int
+    {
+        return substr_count($code, "\n", 0, $position) + 1;
+    }
+}

--- a/src/Rules/DeprecatedActionFormRule.php
+++ b/src/Rules/DeprecatedActionFormRule.php
@@ -3,6 +3,7 @@
 namespace Filacheck\Rules;
 
 use Filacheck\Enums\RuleCategory;
+use Filacheck\Rules\Concerns\CalculatesLineNumbers;
 use Filacheck\Support\Context;
 use Filacheck\Support\Violation;
 use PhpParser\Node;
@@ -13,6 +14,7 @@ use PhpParser\Node\Name;
 
 class DeprecatedActionFormRule implements FixableRule
 {
+    use CalculatesLineNumbers;
     private const ACTION_CLASSES = [
         'Action',
         'EditAction',
@@ -65,7 +67,7 @@ class DeprecatedActionFormRule implements FixableRule
                 level: 'warning',
                 message: 'The `form()` method on actions is deprecated in Filament 4.',
                 file: $context->file,
-                line: $node->getLine(),
+                line: $this->getLineFromPosition($context->code, $startPos),
                 suggestion: 'Use `schema()` instead of `form()`.',
                 isFixable: true,
                 startPos: $startPos,

--- a/src/Rules/DeprecatedEmptyLabelRule.php
+++ b/src/Rules/DeprecatedEmptyLabelRule.php
@@ -3,6 +3,7 @@
 namespace Filacheck\Rules;
 
 use Filacheck\Enums\RuleCategory;
+use Filacheck\Rules\Concerns\CalculatesLineNumbers;
 use Filacheck\Support\Context;
 use Filacheck\Support\Violation;
 use PhpParser\Node;
@@ -14,6 +15,7 @@ use PhpParser\Node\Scalar\String_;
 
 class DeprecatedEmptyLabelRule implements FixableRule
 {
+    use CalculatesLineNumbers;
     public function name(): string
     {
         return 'deprecated-empty-label';
@@ -70,7 +72,7 @@ class DeprecatedEmptyLabelRule implements FixableRule
                     level: 'warning',
                     message: 'Using `label(\'\')` to hide labels is deprecated.',
                     file: $context->file,
-                    line: $node->getLine(),
+                    line: $this->getLineFromPosition($context->code, $startPos),
                     suggestion: 'Use `iconButton()` instead of `label(\'\')` for Actions.',
                     isFixable: true,
                     startPos: $startPos,
@@ -85,7 +87,7 @@ class DeprecatedEmptyLabelRule implements FixableRule
                 level: 'warning',
                 message: 'Using `label(\'\')` to hide labels is deprecated.',
                 file: $context->file,
-                line: $node->getLine(),
+                line: $this->getLineFromPosition($context->code, $startPos),
                 suggestion: 'Use `hiddenLabel()` instead of `label(\'\')`.',
                 isFixable: true,
                 startPos: $startPos,

--- a/src/Rules/DeprecatedFilterFormRule.php
+++ b/src/Rules/DeprecatedFilterFormRule.php
@@ -3,6 +3,7 @@
 namespace Filacheck\Rules;
 
 use Filacheck\Enums\RuleCategory;
+use Filacheck\Rules\Concerns\CalculatesLineNumbers;
 use Filacheck\Support\Context;
 use Filacheck\Support\Violation;
 use PhpParser\Node;
@@ -13,6 +14,7 @@ use PhpParser\Node\Name;
 
 class DeprecatedFilterFormRule implements FixableRule
 {
+    use CalculatesLineNumbers;
     private const FILTER_CLASSES = [
         'Filter',
         'SelectFilter',
@@ -57,7 +59,7 @@ class DeprecatedFilterFormRule implements FixableRule
                 level: 'warning',
                 message: 'The `form()` method on filters is deprecated in Filament 4.',
                 file: $context->file,
-                line: $node->getLine(),
+                line: $this->getLineFromPosition($context->code, $startPos),
                 suggestion: 'Use `schema()` instead of `form()`.',
                 isFixable: true,
                 startPos: $startPos,

--- a/src/Rules/DeprecatedFormsSetRule.php
+++ b/src/Rules/DeprecatedFormsSetRule.php
@@ -3,6 +3,7 @@
 namespace Filacheck\Rules;
 
 use Filacheck\Enums\RuleCategory;
+use Filacheck\Rules\Concerns\CalculatesLineNumbers;
 use Filacheck\Support\Context;
 use Filacheck\Support\Violation;
 use PhpParser\Node;
@@ -10,6 +11,7 @@ use PhpParser\Node\Stmt\Use_;
 
 class DeprecatedFormsSetRule implements FixableRule
 {
+    use CalculatesLineNumbers;
     public function name(): string
     {
         return 'deprecated-forms-set';
@@ -37,7 +39,7 @@ class DeprecatedFormsSetRule implements FixableRule
                     level: 'warning',
                     message: 'The `Filament\Forms\Set` class namespace is deprecated.',
                     file: $context->file,
-                    line: $node->getLine(),
+                    line: $this->getLineFromPosition($context->code, $startPos),
                     suggestion: 'Use `Filament\Schemas\Components\Utilities\Set` instead of `Filament\Forms\Set`.',
                     isFixable: true,
                     startPos: $startPos,

--- a/src/Rules/DeprecatedImageColumnSizeRule.php
+++ b/src/Rules/DeprecatedImageColumnSizeRule.php
@@ -3,6 +3,7 @@
 namespace Filacheck\Rules;
 
 use Filacheck\Enums\RuleCategory;
+use Filacheck\Rules\Concerns\CalculatesLineNumbers;
 use Filacheck\Support\Context;
 use Filacheck\Support\Violation;
 use PhpParser\Node;
@@ -13,6 +14,7 @@ use PhpParser\Node\Name;
 
 class DeprecatedImageColumnSizeRule implements FixableRule
 {
+    use CalculatesLineNumbers;
     public function name(): string
     {
         return 'deprecated-image-column-size';
@@ -50,7 +52,7 @@ class DeprecatedImageColumnSizeRule implements FixableRule
                 level: 'warning',
                 message: 'The `size()` method on ImageColumn is deprecated.',
                 file: $context->file,
-                line: $node->getLine(),
+                line: $this->getLineFromPosition($context->code, $startPos),
                 suggestion: 'Use `imageSize()` instead of `size()`.',
                 isFixable: true,
                 startPos: $startPos,

--- a/src/Rules/DeprecatedMutateFormDataUsingRule.php
+++ b/src/Rules/DeprecatedMutateFormDataUsingRule.php
@@ -3,6 +3,7 @@
 namespace Filacheck\Rules;
 
 use Filacheck\Enums\RuleCategory;
+use Filacheck\Rules\Concerns\CalculatesLineNumbers;
 use Filacheck\Support\Context;
 use Filacheck\Support\Violation;
 use PhpParser\Node;
@@ -11,6 +12,7 @@ use PhpParser\Node\Identifier;
 
 class DeprecatedMutateFormDataUsingRule implements FixableRule
 {
+    use CalculatesLineNumbers;
     public function name(): string
     {
         return 'deprecated-mutate-form-data-using';
@@ -44,7 +46,7 @@ class DeprecatedMutateFormDataUsingRule implements FixableRule
                 level: 'warning',
                 message: 'The `mutateFormDataUsing()` method is deprecated in Filament v4.',
                 file: $context->file,
-                line: $node->getLine(),
+                line: $this->getLineFromPosition($context->code, $startPos),
                 suggestion: 'Use `mutateDataUsing()` instead.',
                 isFixable: true,
                 startPos: $startPos,

--- a/src/Rules/DeprecatedPlaceholderRule.php
+++ b/src/Rules/DeprecatedPlaceholderRule.php
@@ -3,6 +3,7 @@
 namespace Filacheck\Rules;
 
 use Filacheck\Enums\RuleCategory;
+use Filacheck\Rules\Concerns\CalculatesLineNumbers;
 use Filacheck\Support\Context;
 use Filacheck\Support\Violation;
 use PhpParser\Node;
@@ -12,6 +13,7 @@ use PhpParser\Node\Name;
 
 class DeprecatedPlaceholderRule implements Rule
 {
+    use CalculatesLineNumbers;
     public function name(): string
     {
         return 'deprecated-placeholder';
@@ -52,7 +54,7 @@ class DeprecatedPlaceholderRule implements Rule
                 level: 'warning',
                 message: 'The `Placeholder` component is deprecated in Filament v4.',
                 file: $context->file,
-                line: $node->getLine(),
+                line: $this->getLineFromPosition($context->code, $node->name->getStartFilePos()),
                 suggestion: 'Use `TextEntry::make()->state()` instead.',
             ),
         ];

--- a/src/Rules/DeprecatedReactiveRule.php
+++ b/src/Rules/DeprecatedReactiveRule.php
@@ -3,6 +3,7 @@
 namespace Filacheck\Rules;
 
 use Filacheck\Enums\RuleCategory;
+use Filacheck\Rules\Concerns\CalculatesLineNumbers;
 use Filacheck\Support\Context;
 use Filacheck\Support\Violation;
 use PhpParser\Node;
@@ -11,6 +12,7 @@ use PhpParser\Node\Identifier;
 
 class DeprecatedReactiveRule implements FixableRule
 {
+    use CalculatesLineNumbers;
     public function name(): string
     {
         return 'deprecated-reactive';
@@ -44,7 +46,7 @@ class DeprecatedReactiveRule implements FixableRule
                 level: 'warning',
                 message: 'The `reactive()` method is deprecated.',
                 file: $context->file,
-                line: $node->getLine(),
+                line: $this->getLineFromPosition($context->code, $startPos),
                 suggestion: 'Use `live()` instead of `reactive()`.',
                 isFixable: true,
                 startPos: $startPos,

--- a/src/Scanner/ResourceScanner.php
+++ b/src/Scanner/ResourceScanner.php
@@ -45,13 +45,13 @@ class ResourceScanner
     /**
      * @return Violation[]
      */
-    public function scan(string $directory): array
+    public function scan(string $directory, ?string $basePath = null): array
     {
         $violations = [];
         $files = $this->findPhpFiles($directory);
 
         foreach ($files as $file) {
-            $fileViolations = $this->scanFile($file);
+            $fileViolations = $this->scanFile($file, $basePath);
             $violations = array_merge($violations, $fileViolations);
         }
 
@@ -141,12 +141,20 @@ class ResourceScanner
     /**
      * @return Violation[]
      */
-    private function scanFile(SplFileInfo $file): array
+    private function scanFile(SplFileInfo $file, ?string $basePath = null): array
     {
         $code = file_get_contents($file->getPathname());
+        $filePath = $file->getPathname();
+
+        // Make path relative to basePath if provided
+        if ($basePath !== null && str_starts_with($filePath, $basePath)) {
+            $filePath = substr($filePath, strlen($basePath) + 1);
+        }
+
         $context = new Context(
-            file: $file->getPathname(),
+            file: $filePath,
             code: $code,
+            basePath: $basePath,
         );
 
         try {


### PR DESCRIPTION
FilaCheck was reporting incorrect line numbers:

### Example

```php
Select::make('category_scope')     // line 47 (was being reported)
    ->label('Category Scope')
    ->options([...])
    ->default('all')
    ->required()
    ->reactive()                    // line 55 (actual location)
    ->native(false),
```

The tool would report line 47 instead of line 55 where `->reactive()` actually appears.

Resolves #7