### PR TITLE
New `action-in-bulk-action-group` Rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,13 @@ vendor/bin/filacheck --fix --backup
 
 ## Available Rules (Free)
 
-FilaCheck includes the following rules for detecting deprecated code patterns:
+FilaCheck includes the following rules for detecting deprecated code patterns and common issues:
+
+### Best Practices
+
+| Rule | Description | Fixable |
+|------|-------------|---------|
+| `action-in-bulk-action-group` | Detects `Action::make()` inside `BulkActionGroup::make()` which should be `BulkAction::make()` | Yes |
 
 ### Deprecated Code
 

--- a/bin/filacheck
+++ b/bin/filacheck
@@ -12,11 +12,12 @@ use Filacheck\Support\RuleRegistry;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
 // Autoload handling for different installation contexts
-$autoloadPaths = [
-    __DIR__.'/../vendor/autoload.php',           // Package development
+$autoloadPaths = array_filter([
+    $GLOBALS['_composer_autoload_path'] ?? null, // Composer bin proxy (most reliable)
     __DIR__.'/../../../autoload.php',            // Installed as dependency
     __DIR__.'/../../../../vendor/autoload.php',  // Laravel project context
-];
+    __DIR__.'/../vendor/autoload.php',           // Package development
+]);
 
 $autoloaded = false;
 foreach ($autoloadPaths as $autoloadPath) {

--- a/src/FilacheckServiceProvider.php
+++ b/src/FilacheckServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Filacheck;
 
+use Filacheck\Rules\ActionInBulkActionGroupRule;
 use Filacheck\Rules\DeprecatedActionFormRule;
 use Filacheck\Rules\DeprecatedEmptyLabelRule;
 use Filacheck\Rules\DeprecatedFilterFormRule;
@@ -39,6 +40,7 @@ class FilacheckServiceProvider extends ServiceProvider
             DeprecatedFormsSetRule::class,
             DeprecatedImageColumnSizeRule::class,
             DeprecatedViewPropertyRule::class,
+            ActionInBulkActionGroupRule::class,
         ];
     }
 }

--- a/src/Rules/ActionInBulkActionGroupRule.php
+++ b/src/Rules/ActionInBulkActionGroupRule.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Filacheck\Rules;
+
+use Filacheck\Enums\RuleCategory;
+use Filacheck\Rules\Concerns\AddsImport;
+use Filacheck\Rules\Concerns\CalculatesLineNumbers;
+use Filacheck\Support\Context;
+use Filacheck\Support\Violation;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\NodeFinder;
+
+class ActionInBulkActionGroupRule implements FixableRule
+{
+    use AddsImport;
+    use CalculatesLineNumbers;
+
+    public function name(): string
+    {
+        return 'action-in-bulk-action-group';
+    }
+
+    public function category(): RuleCategory
+    {
+        return RuleCategory::BestPractices;
+    }
+
+    public function check(Node $node, Context $context): array
+    {
+        if (! $node instanceof ClassMethod) {
+            return [];
+        }
+
+        if (! $this->hasTableParameter($node)) {
+            return [];
+        }
+
+        $violations = [];
+        $nodeFinder = new NodeFinder;
+        $reported = [];
+
+        $isActionMake = function (Node $n): bool {
+            return $n instanceof StaticCall
+                && $n->class instanceof Name
+                && class_basename($n->class->toString()) === 'Action'
+                && $n->name instanceof Identifier
+                && $n->name->name === 'make';
+        };
+
+        // Check inside toolbarActions() for Action::make() in BulkActionGroup or directly
+        $toolbarActionsMethods = $nodeFinder->find($node, function (Node $n) {
+            return $n instanceof MethodCall
+                && $n->name instanceof Identifier
+                && $n->name->name === 'toolbarActions';
+        });
+
+        foreach ($toolbarActionsMethods as $toolbarActionsMethod) {
+            // Only search within args, not the entire node.
+            // The node's `var` property contains earlier chained calls
+            // (e.g. ->recordActions([...])->toolbarActions([...])),
+            // and searching the full node would cause false positives.
+            foreach ($toolbarActionsMethod->getArgs() as $arg) {
+                // Check inside BulkActionGroup::make()
+                $bulkActionGroups = $nodeFinder->find($arg, function (Node $n) {
+                    return $n instanceof StaticCall
+                        && $n->class instanceof Name
+                        && class_basename($n->class->toString()) === 'BulkActionGroup'
+                        && $n->name instanceof Identifier
+                        && $n->name->name === 'make';
+                });
+
+                foreach ($bulkActionGroups as $bulkActionGroup) {
+                    $actionCalls = $nodeFinder->find($bulkActionGroup, $isActionMake);
+
+                    foreach ($actionCalls as $actionCall) {
+                        $startPos = $actionCall->class->getStartFilePos();
+                        $reported[$startPos] = true;
+
+                        $violations[] = $this->buildActionViolation($actionCall, $context);
+                    }
+                }
+
+                // Check Action::make() directly inside toolbarActions (not in BulkActionGroup)
+                $actionCalls = $nodeFinder->find($arg, $isActionMake);
+
+                foreach ($actionCalls as $actionCall) {
+                    $startPos = $actionCall->class->getStartFilePos();
+
+                    if (isset($reported[$startPos])) {
+                        continue;
+                    }
+
+                    $violations[] = $this->buildActionViolation($actionCall, $context);
+                }
+            }
+        }
+
+        if (! empty($violations)) {
+            $importViolation = $this->buildImportViolation(
+                'use Filament\Actions\BulkAction;',
+                $context,
+            );
+
+            if ($importViolation !== null) {
+                $violations[] = $importViolation;
+            }
+        }
+
+        return $violations;
+    }
+
+    private function hasTableParameter(ClassMethod $node): bool
+    {
+        foreach ($node->params as $param) {
+            if ($param->type instanceof Name && class_basename($param->type->toString()) === 'Table') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function buildActionViolation(StaticCall $actionCall, Context $context): Violation
+    {
+        $classNode = $actionCall->class;
+        $startPos = $classNode->getStartFilePos();
+        $endPos = $classNode->getEndFilePos() + 1;
+
+        return new Violation(
+            level: 'error',
+            message: '`Action::make()` is used inside `toolbarActions()`. Use `BulkAction::make()` instead.',
+            file: $context->file,
+            line: $this->getLineFromPosition($context->code, $startPos),
+            suggestion: 'Replace `Action::make()` with `BulkAction::make()`.',
+            isFixable: true,
+            startPos: $startPos,
+            endPos: $endPos,
+            replacement: 'BulkAction',
+        );
+    }
+}

--- a/src/Rules/Concerns/AddsImport.php
+++ b/src/Rules/Concerns/AddsImport.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Filacheck\Rules\Concerns;
+
+use Filacheck\Support\Context;
+use Filacheck\Support\Violation;
+
+trait AddsImport
+{
+    private array $importAddedForFiles = [];
+
+    protected function buildImportViolation(string $useStatement, Context $context): ?Violation
+    {
+        if (
+            str_contains($context->code, $useStatement)
+            || isset($this->importAddedForFiles[$context->file])
+        ) {
+            return null;
+        }
+
+        $this->importAddedForFiles[$context->file] = true;
+
+        $importStatement = $useStatement . "\n";
+
+        if (preg_match_all('/^use\s+[^;]+;[ \t]*\n/m', $context->code, $matches, PREG_OFFSET_CAPTURE)) {
+            $lastMatch = end($matches[0]);
+            $insertionPoint = $lastMatch[1] + strlen($lastMatch[0]);
+        } elseif (preg_match('/^<\?php\s*/m', $context->code, $match, PREG_OFFSET_CAPTURE)) {
+            $insertionPoint = $match[0][1] + strlen($match[0][0]);
+            $importStatement = "\n" . $importStatement;
+        } else {
+            $insertionPoint = 0;
+        }
+
+        return new Violation(
+            level: 'warning',
+            message: "Missing import: {$useStatement}",
+            file: $context->file,
+            line: 1,
+            isFixable: true,
+            startPos: $insertionPoint,
+            endPos: $insertionPoint,
+            replacement: $importStatement,
+        );
+    }
+}

--- a/tests/Rules/ActionInBulkActionGroupRuleTest.php
+++ b/tests/Rules/ActionInBulkActionGroupRuleTest.php
@@ -1,0 +1,395 @@
+<?php
+
+use Filacheck\Rules\ActionInBulkActionGroupRule;
+
+it('detects Action::make() inside BulkActionGroup::make()', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Actions\BulkActionGroup;
+use Filament\Tables\Table;
+
+class TestResource
+{
+    public function table(Table $table): Table
+    {
+        return $table
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    Action::make('approve')
+                        ->label('Approve Selected'),
+                ]),
+            ]);
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new ActionInBulkActionGroupRule, $code);
+
+    $this->assertViolationCount(2, $violations);
+    $this->assertViolationContains('Action::make()', $violations);
+});
+
+it('passes when BulkAction::make() is used inside BulkActionGroup', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Actions\BulkAction;
+use Filament\Tables\Actions\BulkActionGroup;
+use Filament\Tables\Table;
+
+class TestResource
+{
+    public function table(Table $table): Table
+    {
+        return $table
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    BulkAction::make('approve')
+                        ->label('Approve Selected'),
+                ]),
+            ]);
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new ActionInBulkActionGroupRule, $code);
+
+    $this->assertNoViolations($violations);
+});
+
+it('detects multiple Action::make() inside BulkActionGroup', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Actions\BulkActionGroup;
+use Filament\Tables\Table;
+
+class TestResource
+{
+    public function table(Table $table): Table
+    {
+        return $table
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    Action::make('approve')
+                        ->label('Approve Selected'),
+                    Action::make('reject')
+                        ->label('Reject Selected'),
+                ]),
+            ]);
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new ActionInBulkActionGroupRule, $code);
+
+    $this->assertViolationCount(3, $violations);
+});
+
+it('ignores Action::make() outside toolbarActions', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Table;
+
+class TestResource
+{
+    public function table(Table $table): Table
+    {
+        return $table
+            ->headerActions([
+                Action::make('create')
+                    ->label('Create'),
+            ]);
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new ActionInBulkActionGroupRule, $code);
+
+    $this->assertNoViolations($violations);
+});
+
+it('ignores Action::make() in recordActions chained with toolbarActions', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Actions\BulkAction;
+use Filament\Tables\Actions\BulkActionGroup;
+use Filament\Tables\Table;
+
+class TestResource
+{
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([])
+            ->recordActions([
+                Action::make('view'),
+                Action::make('edit'),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    BulkAction::make('approve'),
+                ]),
+            ]);
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new ActionInBulkActionGroupRule, $code);
+
+    $this->assertNoViolations($violations);
+});
+
+it('only flags Action::make() in toolbarActions, not in other chained methods', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Actions\BulkActionGroup;
+use Filament\Tables\Table;
+
+class TestResource
+{
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([])
+            ->recordActions([
+                Action::make('view'),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    Action::make('approve'),
+                ]),
+            ]);
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new ActionInBulkActionGroupRule, $code);
+
+    // 1 for Action::make('approve') + 1 for the import = 2
+    $this->assertViolationCount(2, $violations);
+});
+
+it('ignores Action::make() outside table method', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Tables\Actions\Action;
+
+class TestResource
+{
+    public function form(): array
+    {
+        return [
+            Action::make('test'),
+        ];
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new ActionInBulkActionGroupRule, $code);
+
+    $this->assertNoViolations($violations);
+});
+
+it('marks violations as fixable', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Actions\BulkActionGroup;
+use Filament\Tables\Table;
+
+class TestResource
+{
+    public function table(Table $table): Table
+    {
+        return $table
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    Action::make('approve'),
+                ]),
+            ]);
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new ActionInBulkActionGroupRule, $code);
+
+    $this->assertViolationIsFixable($violations);
+});
+
+it('fixes Action::make() to BulkAction::make()', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Actions\BulkActionGroup;
+use Filament\Tables\Table;
+
+class TestResource
+{
+    public function table(Table $table): Table
+    {
+        return $table
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    Action::make('approve')
+                        ->label('Approve Selected'),
+                ]),
+            ]);
+    }
+}
+PHP;
+
+    $fixedCode = $this->scanAndFix(new ActionInBulkActionGroupRule, $code);
+
+    expect($fixedCode)->toContain('BulkAction::make(\'approve\')');
+    expect($fixedCode)->not->toMatch('/[^k]Action::make/');
+});
+
+it('adds BulkAction import when fixing', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Actions\BulkActionGroup;
+use Filament\Tables\Table;
+
+class TestResource
+{
+    public function table(Table $table): Table
+    {
+        return $table
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    Action::make('approve'),
+                ]),
+            ]);
+    }
+}
+PHP;
+
+    $fixedCode = $this->scanAndFix(new ActionInBulkActionGroupRule, $code);
+
+    expect($fixedCode)->toContain('use Filament\Actions\BulkAction;');
+});
+
+it('does not duplicate BulkAction import if already present', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Actions\BulkAction;
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Actions\BulkActionGroup;
+use Filament\Tables\Table;
+
+class TestResource
+{
+    public function table(Table $table): Table
+    {
+        return $table
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    Action::make('approve'),
+                ]),
+            ]);
+    }
+}
+PHP;
+
+    $fixedCode = $this->scanAndFix(new ActionInBulkActionGroupRule, $code);
+
+    expect(substr_count($fixedCode, 'use Filament\Actions\BulkAction;'))->toBe(1);
+});
+
+it('detects Action::make() directly inside toolbarActions without BulkActionGroup', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Table;
+
+class TestResource
+{
+    public function table(Table $table): Table
+    {
+        return $table
+            ->toolbarActions([
+                Action::make('approve')
+                    ->label('Approve Selected'),
+            ]);
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new ActionInBulkActionGroupRule, $code);
+
+    $this->assertViolationCount(2, $violations);
+    $this->assertViolationContains('Action::make()', $violations);
+});
+
+it('fixes Action::make() directly inside toolbarActions', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Table;
+
+class TestResource
+{
+    public function table(Table $table): Table
+    {
+        return $table
+            ->toolbarActions([
+                Action::make('approve')
+                    ->label('Approve Selected'),
+            ]);
+    }
+}
+PHP;
+
+    $fixedCode = $this->scanAndFix(new ActionInBulkActionGroupRule, $code);
+
+    expect($fixedCode)->toContain('BulkAction::make(\'approve\')');
+    expect($fixedCode)->not->toMatch('/[^k]Action::make/');
+    expect($fixedCode)->toContain('use Filament\Actions\BulkAction;');
+});
+
+it('detects Action::make() in a non-table method with Table type-hinted parameter', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Actions\BulkActionGroup;
+use Filament\Tables\Table;
+
+class ReviewsTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    Action::make('approve')
+                        ->label('Approve Selected'),
+                ]),
+            ]);
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new ActionInBulkActionGroupRule, $code);
+
+    $this->assertViolationCount(2, $violations);
+    $this->assertViolationContains('Action::make()', $violations);
+});

--- a/tests/Support/RuleRegistryTest.php
+++ b/tests/Support/RuleRegistryTest.php
@@ -66,5 +66,6 @@ it('registers all rules from FilacheckServiceProvider', function () {
             \Filacheck\Rules\DeprecatedFormsSetRule::class,
             \Filacheck\Rules\DeprecatedImageColumnSizeRule::class,
             \Filacheck\Rules\DeprecatedViewPropertyRule::class,
+            \Filacheck\Rules\ActionInBulkActionGroupRule::class,
     ]);
 });


### PR DESCRIPTION
Adds a new best-practices rule that detects `Action::make()` used inside `toolbarActions()` / `BulkActionGroup::make()` and suggests replacing it with `BulkAction::make()`. The rule is auto-fixable and also adds the missing `use Filament\Actions\BulkAction;` import.

This is a common mistake in AI-generated Filament code — the code compiles and looks correct at first glance, but bulk actions require `BulkAction::make()` to receive the selected `$records` collection at runtime.

### What it detects

- `Action::make()` inside `BulkActionGroup::make()`
- `Action::make()` directly inside `toolbarActions()`
- Works with any method that accepts a `Table` type-hinted parameter (not just `table()` — e.g. `configure(Table $table)`)

### Before

```php
use Filament\Tables\Actions\Action;
use Filament\Tables\Actions\BulkActionGroup;
use Filament\Tables\Table;

class PostResource extends Resource
{
    public function table(Table $table): Table
    {
        return $table
            ->toolbarActions([
                BulkActionGroup::make([
                    // Wrong:
                    Action::make('approve')
                        ->label('Approve Selected')
                        ->action(function (Collection $records) {
                            // ...
                        }),
                ]),
            ]);
    }
}
```

### After

```php
use Filament\Actions\BulkAction;
use Filament\Tables\Actions\BulkActionGroup;
use Filament\Tables\Table;

class PostResource extends Resource
{
    public function table(Table $table): Table
    {
        return $table
            ->toolbarActions([
                BulkActionGroup::make([
                    // Correct:
                    BulkAction::make('approve')
                        ->label('Approve Selected')
                        ->action(function (Collection $records) {
                            // ...
                        }),
                ]),
            ]);
    }
}
```

Resolves #11 