### PR TITLE
Add New `deprecated-bulk-actions` Rule

### DIFF
--- a/src/FilacheckServiceProvider.php
+++ b/src/FilacheckServiceProvider.php
@@ -4,6 +4,7 @@ namespace Filacheck;
 
 use Filacheck\Rules\ActionInBulkActionGroupRule;
 use Filacheck\Rules\DeprecatedActionFormRule;
+use Filacheck\Rules\DeprecatedBulkActionsRule;
 use Filacheck\Rules\DeprecatedEmptyLabelRule;
 use Filacheck\Rules\DeprecatedFilterFormRule;
 use Filacheck\Rules\DeprecatedFormsSetRule;
@@ -41,6 +42,7 @@ class FilacheckServiceProvider extends ServiceProvider
             DeprecatedImageColumnSizeRule::class,
             DeprecatedViewPropertyRule::class,
             ActionInBulkActionGroupRule::class,
+            DeprecatedBulkActionsRule::class,
         ];
     }
 }

--- a/src/Rules/DeprecatedBulkActionsRule.php
+++ b/src/Rules/DeprecatedBulkActionsRule.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Filacheck\Rules;
+
+use Filacheck\Enums\RuleCategory;
+use Filacheck\Rules\Concerns\CalculatesLineNumbers;
+use Filacheck\Support\Context;
+use Filacheck\Support\Violation;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\NodeFinder;
+
+class DeprecatedBulkActionsRule implements FixableRule
+{
+    use CalculatesLineNumbers;
+
+    public function name(): string
+    {
+        return 'deprecated-bulk-actions';
+    }
+
+    public function category(): RuleCategory
+    {
+        return RuleCategory::Deprecated;
+    }
+
+    public function check(Node $node, Context $context): array
+    {
+        if (! $node instanceof ClassMethod) {
+            return [];
+        }
+
+        if (! $this->hasTableParameter($node)) {
+            return [];
+        }
+
+        $violations = [];
+        $nodeFinder = new NodeFinder;
+
+        $bulkActionsCalls = $nodeFinder->find($node, function (Node $n) {
+            return $n instanceof MethodCall
+                && $n->name instanceof Identifier
+                && $n->name->name === 'bulkActions';
+        });
+
+        foreach ($bulkActionsCalls as $call) {
+            $nameNode = $call->name;
+            $startPos = $nameNode->getStartFilePos();
+            $endPos = $nameNode->getEndFilePos() + 1;
+
+            $violations[] = new Violation(
+                level: 'warning',
+                message: 'The `bulkActions()` method is deprecated.',
+                file: $context->file,
+                line: $this->getLineFromPosition($context->code, $startPos),
+                suggestion: 'Use `toolbarActions()` instead of `bulkActions()`.',
+                isFixable: true,
+                startPos: $startPos,
+                endPos: $endPos,
+                replacement: 'toolbarActions',
+            );
+        }
+
+        return $violations;
+    }
+
+    private function hasTableParameter(ClassMethod $node): bool
+    {
+        foreach ($node->params as $param) {
+            if ($param->type instanceof Name && class_basename($param->type->toString()) === 'Table') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Rules/DeprecatedBulkActionsRuleTest.php
+++ b/tests/Rules/DeprecatedBulkActionsRuleTest.php
@@ -1,0 +1,167 @@
+<?php
+
+use Filacheck\Rules\DeprecatedBulkActionsRule;
+
+it('detects bulkActions method usage in table method', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Tables\Actions\BulkActionGroup;
+use Filament\Tables\Actions\BulkAction;
+use Filament\Tables\Table;
+
+class TestResource
+{
+    public function table(Table $table): Table
+    {
+        return $table
+            ->bulkActions([
+                BulkActionGroup::make([
+                    BulkAction::make('delete'),
+                ]),
+            ]);
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new DeprecatedBulkActionsRule, $code);
+
+    $this->assertViolationCount(1, $violations);
+    $this->assertViolationContains('bulkActions()', $violations);
+});
+
+it('passes when toolbarActions is used instead of bulkActions', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Tables\Actions\BulkActionGroup;
+use Filament\Tables\Actions\BulkAction;
+use Filament\Tables\Table;
+
+class TestResource
+{
+    public function table(Table $table): Table
+    {
+        return $table
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    BulkAction::make('delete'),
+                ]),
+            ]);
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new DeprecatedBulkActionsRule, $code);
+
+    $this->assertNoViolations($violations);
+});
+
+it('detects multiple bulkActions calls', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Tables\Table;
+
+class TestResource
+{
+    public function table(Table $table): Table
+    {
+        $table->bulkActions([]);
+
+        return $table->bulkActions([]);
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new DeprecatedBulkActionsRule, $code);
+
+    $this->assertViolationCount(2, $violations);
+});
+
+it('ignores bulkActions outside a method with Table parameter', function () {
+    $code = <<<'PHP'
+<?php
+
+class TestResource
+{
+    public function form(): array
+    {
+        return $this->bulkActions([]);
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new DeprecatedBulkActionsRule, $code);
+
+    $this->assertNoViolations($violations);
+});
+
+it('marks violations as fixable', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Tables\Table;
+
+class TestResource
+{
+    public function table(Table $table): Table
+    {
+        return $table->bulkActions([]);
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new DeprecatedBulkActionsRule, $code);
+
+    $this->assertViolationIsFixable($violations);
+});
+
+it('fixes bulkActions to toolbarActions', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Tables\Table;
+
+class TestResource
+{
+    public function table(Table $table): Table
+    {
+        return $table
+            ->bulkActions([
+                BulkActionGroup::make([
+                    BulkAction::make('delete'),
+                ]),
+            ]);
+    }
+}
+PHP;
+
+    $fixedCode = $this->scanAndFix(new DeprecatedBulkActionsRule, $code);
+
+    expect($fixedCode)->toContain('->toolbarActions(');
+    expect($fixedCode)->not->toContain('->bulkActions(');
+});
+
+it('fixes multiple bulkActions occurrences', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Tables\Table;
+
+class TestResource
+{
+    public function table(Table $table): Table
+    {
+        $table->bulkActions([]);
+
+        return $table->bulkActions([]);
+    }
+}
+PHP;
+
+    $fixedCode = $this->scanAndFix(new DeprecatedBulkActionsRule, $code);
+
+    expect(substr_count($fixedCode, '->toolbarActions('))->toBe(2);
+    expect($fixedCode)->not->toContain('->bulkActions(');
+});

--- a/tests/Support/RuleRegistryTest.php
+++ b/tests/Support/RuleRegistryTest.php
@@ -67,5 +67,6 @@ it('registers all rules from FilacheckServiceProvider', function () {
             \Filacheck\Rules\DeprecatedImageColumnSizeRule::class,
             \Filacheck\Rules\DeprecatedViewPropertyRule::class,
             \Filacheck\Rules\ActionInBulkActionGroupRule::class,
+            \Filacheck\Rules\DeprecatedBulkActionsRule::class,
     ]);
 });


### PR DESCRIPTION
Add a new fixable `deprecated-bulk-actions` rule that detects deprecated `->bulkActions()` calls on `Table` and auto-fixes them to `->toolbarActions()`.

## Before / After

### Before (deprecated)

```php
use Filament\Tables\Table;

class PostResource
{
    public function table(Table $table): Table
    {
        return $table
            ->bulkActions([
                BulkActionGroup::make([
                    BulkAction::make('delete'),
                ]),
            ]);
    }
}
```

### After (fixed)

```php
use Filament\Tables\Table;

class PostResource
{
    public function table(Table $table): Table
    {
        return $table
            ->toolbarActions([
                BulkActionGroup::make([
                    BulkAction::make('delete'),
                ]),
            ]);
    }
}
```

## Test plan

- [x] Detects `->bulkActions()` in a table method
- [x] Passes when `->toolbarActions()` is used
- [x] Detects multiple `->bulkActions()` calls
- [x] Ignores `->bulkActions()` outside a method with Table parameter
- [x] Marks violations as fixable
- [x] Fixes `bulkActions` to `toolbarActions`
- [x] Fixes multiple occurrences

Resolves #13 