### PR TITLE
Add New `wrong-tab-namespace` Rule

### DIFF
--- a/src/FilacheckServiceProvider.php
+++ b/src/FilacheckServiceProvider.php
@@ -13,6 +13,7 @@ use Filacheck\Rules\DeprecatedMutateFormDataUsingRule;
 use Filacheck\Rules\DeprecatedPlaceholderRule;
 use Filacheck\Rules\DeprecatedReactiveRule;
 use Filacheck\Rules\DeprecatedViewPropertyRule;
+use Filacheck\Rules\WrongTabNamespaceRule;
 use Filacheck\Support\RuleRegistry;
 use Illuminate\Support\ServiceProvider;
 
@@ -43,6 +44,7 @@ class FilacheckServiceProvider extends ServiceProvider
             DeprecatedViewPropertyRule::class,
             ActionInBulkActionGroupRule::class,
             DeprecatedBulkActionsRule::class,
+            WrongTabNamespaceRule::class,
         ];
     }
 }

--- a/src/Rules/WrongTabNamespaceRule.php
+++ b/src/Rules/WrongTabNamespaceRule.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Filacheck\Rules;
+
+use Filacheck\Enums\RuleCategory;
+use Filacheck\Rules\Concerns\AddsImport;
+use Filacheck\Rules\Concerns\CalculatesLineNumbers;
+use Filacheck\Support\Context;
+use Filacheck\Support\Violation;
+use PhpParser\Node;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Use_;
+
+class WrongTabNamespaceRule implements FixableRule
+{
+    use AddsImport;
+    use CalculatesLineNumbers;
+
+    private const CORRECT_NAMESPACE = 'Filament\Schemas\Components\Tabs\Tab';
+
+    private array $filesWithTabImport = [];
+
+    public function name(): string
+    {
+        return 'wrong-tab-namespace';
+    }
+
+    public function category(): RuleCategory
+    {
+        return RuleCategory::BestPractices;
+    }
+
+    public function check(Node $node, Context $context): array
+    {
+        if ($node instanceof Use_) {
+            return $this->checkImport($node, $context);
+        }
+
+        if ($node instanceof StaticCall) {
+            return $this->checkStaticCall($node, $context);
+        }
+
+        return [];
+    }
+
+    private function checkImport(Use_ $node, Context $context): array
+    {
+        $violations = [];
+
+        foreach ($node->uses as $use) {
+            $name = $use->name->toString();
+            $lastPart = class_basename($name);
+
+            if ($lastPart !== 'Tab') {
+                continue;
+            }
+
+            if ($name === self::CORRECT_NAMESPACE) {
+                $this->filesWithTabImport[$context->file] = true;
+
+                continue;
+            }
+
+            $this->filesWithTabImport[$context->file] = true;
+
+            if (str_starts_with($name, 'Filament\\')) {
+
+                $startPos = $use->name->getStartFilePos();
+                $endPos = $use->name->getEndFilePos() + 1;
+
+                $violations[] = new Violation(
+                    level: 'warning',
+                    message: "Wrong namespace `{$name}`. The correct namespace is `" . self::CORRECT_NAMESPACE . '`.',
+                    file: $context->file,
+                    line: $this->getLineFromPosition($context->code, $startPos),
+                    suggestion: 'Use `' . self::CORRECT_NAMESPACE . "` instead of `{$name}`.",
+                    isFixable: true,
+                    startPos: $startPos,
+                    endPos: $endPos,
+                    replacement: self::CORRECT_NAMESPACE,
+                );
+            }
+        }
+
+        return $violations;
+    }
+
+    private function checkStaticCall(StaticCall $node, Context $context): array
+    {
+        if (! $node->class instanceof Name || ! $node->name instanceof Identifier || $node->name->name !== 'make') {
+            return [];
+        }
+
+        $startPos = $node->class->getStartFilePos();
+        $endPos = $node->class->getEndFilePos() + 1;
+        $originalClassName = substr($context->code, $startPos, $endPos - $startPos);
+        $violations = [];
+
+        if ($originalClassName === 'Tabs\Tab') {
+            $violations[] = new Violation(
+                level: 'warning',
+                message: 'v3-style `Tabs\Tab::make()` usage detected. Use `Tab::make()` with the correct import instead.',
+                file: $context->file,
+                line: $this->getLineFromPosition($context->code, $startPos),
+                suggestion: 'Replace `Tabs\Tab::make()` with `Tab::make()` and add `use Filament\Schemas\Components\Tabs\Tab;`.',
+                isFixable: true,
+                startPos: $startPos,
+                endPos: $endPos,
+                replacement: 'Tab',
+            );
+
+            if (! isset($this->filesWithTabImport[$context->file])) {
+                $importViolation = $this->buildImportViolation(
+                    'use Filament\Schemas\Components\Tabs\Tab;',
+                    $context,
+                );
+
+                if ($importViolation !== null) {
+                    $violations[] = $importViolation;
+                }
+            }
+
+            return $violations;
+        }
+
+        if ($originalClassName === 'Tab') {
+            if (! isset($this->filesWithTabImport[$context->file])) {
+                $importViolation = $this->buildImportViolation(
+                    'use Filament\Schemas\Components\Tabs\Tab;',
+                    $context,
+                );
+
+                if ($importViolation !== null) {
+                    $violations[] = $importViolation;
+                }
+            }
+
+            return $violations;
+        }
+
+        return [];
+    }
+}

--- a/tests/Rules/WrongTabNamespaceRuleTest.php
+++ b/tests/Rules/WrongTabNamespaceRuleTest.php
@@ -1,0 +1,230 @@
+<?php
+
+use Filacheck\Rules\WrongTabNamespaceRule;
+
+it('detects wrong Filament\Schemas\Components\Tab import', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Schemas\Components\Tab;
+
+class TestResource
+{
+    public function form(): void
+    {
+        Tab::make('Settings');
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new WrongTabNamespaceRule, $code);
+
+    $this->assertViolationCount(1, $violations);
+    $this->assertViolationContains('Wrong namespace', $violations);
+});
+
+it('passes with correct Filament\Schemas\Components\Tabs\Tab import', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Schemas\Components\Tabs\Tab;
+
+class TestResource
+{
+    public function form(): void
+    {
+        Tab::make('Settings');
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new WrongTabNamespaceRule, $code);
+
+    $this->assertNoViolations($violations);
+});
+
+it('fixes wrong namespace to correct one', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Schemas\Components\Tab;
+
+class TestResource
+{
+    public function form(): void
+    {
+        Tab::make('Settings');
+    }
+}
+PHP;
+
+    $fixedCode = $this->scanAndFix(new WrongTabNamespaceRule, $code);
+
+    expect($fixedCode)->toContain('use Filament\Schemas\Components\Tabs\Tab;');
+    expect($fixedCode)->not->toContain('use Filament\Schemas\Components\Tab;');
+});
+
+it('detects v3-style Tabs\Tab::make() and fixes to Tab::make()', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Schemas\Components\Tabs;
+
+class TestResource
+{
+    public function form(): void
+    {
+        Tabs\Tab::make('Settings');
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new WrongTabNamespaceRule, $code);
+
+    $this->assertViolationCount(2, $violations);
+    $this->assertViolationContains('Tabs\Tab::make()', $violations);
+
+    $fixedCode = $this->scanAndFix(new WrongTabNamespaceRule, $code);
+
+    expect($fixedCode)->toContain('Tab::make(');
+    expect($fixedCode)->not->toContain('Tabs\Tab::make(');
+    expect($fixedCode)->toContain('use Filament\Schemas\Components\Tabs\Tab;');
+});
+
+it('adds missing Tab import when Tab::make() used without import', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Schemas\Components\Tabs;
+
+class TestResource
+{
+    public function form(): void
+    {
+        Tab::make('Settings');
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new WrongTabNamespaceRule, $code);
+
+    $this->assertViolationCount(1, $violations);
+    $this->assertViolationContains('Missing import', $violations);
+
+    $fixedCode = $this->scanAndFix(new WrongTabNamespaceRule, $code);
+
+    expect($fixedCode)->toContain('use Filament\Schemas\Components\Tabs\Tab;');
+});
+
+it('does not report violation when correct import and Tab::make() usage', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Schemas\Components\Tabs\Tab;
+
+class TestResource
+{
+    public function form(): void
+    {
+        Tab::make('Settings');
+        Tab::make('Advanced');
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new WrongTabNamespaceRule, $code);
+
+    $this->assertNoViolations($violations);
+});
+
+it('detects v3 Forms\Components\Tab import and fixes it', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Forms\Components\Tab;
+
+class TestResource
+{
+    public function form(): void
+    {
+        Tab::make('Settings');
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new WrongTabNamespaceRule, $code);
+
+    $this->assertViolationCount(1, $violations);
+    $this->assertViolationContains('Wrong namespace', $violations);
+
+    $fixedCode = $this->scanAndFix(new WrongTabNamespaceRule, $code);
+
+    expect($fixedCode)->toContain('use Filament\Schemas\Components\Tabs\Tab;');
+    expect($fixedCode)->not->toContain('use Filament\Forms\Components\Tab;');
+});
+
+it('detects v3 Forms\Components\Tabs\Tab import and fixes it', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Forms\Components\Tabs\Tab;
+
+class TestResource
+{
+    public function form(): void
+    {
+        Tab::make('Settings');
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new WrongTabNamespaceRule, $code);
+
+    $this->assertViolationCount(1, $violations);
+    $this->assertViolationContains('Wrong namespace', $violations);
+
+    $fixedCode = $this->scanAndFix(new WrongTabNamespaceRule, $code);
+
+    expect($fixedCode)->toContain('use Filament\Schemas\Components\Tabs\Tab;');
+    expect($fixedCode)->not->toContain('use Filament\Forms\Components\Tabs\Tab;');
+});
+
+it('ignores non-Filament Tab imports', function () {
+    $code = <<<'PHP'
+<?php
+
+use App\Models\Tab;
+
+class TestResource
+{
+    public function form(): void
+    {
+        Tab::make('Settings');
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new WrongTabNamespaceRule, $code);
+
+    $this->assertNoViolations($violations);
+});
+
+it('marks all violations as fixable', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Schemas\Components\Tab;
+
+class TestResource
+{
+    public function form(): void
+    {
+        Tab::make('Settings');
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new WrongTabNamespaceRule, $code);
+
+    $this->assertViolationIsFixable($violations);
+});

--- a/tests/Support/RuleRegistryTest.php
+++ b/tests/Support/RuleRegistryTest.php
@@ -68,5 +68,6 @@ it('registers all rules from FilacheckServiceProvider', function () {
             \Filacheck\Rules\DeprecatedViewPropertyRule::class,
             \Filacheck\Rules\ActionInBulkActionGroupRule::class,
             \Filacheck\Rules\DeprecatedBulkActionsRule::class,
+            \Filacheck\Rules\WrongTabNamespaceRule::class,
     ]);
 });


### PR DESCRIPTION
Adds a new `wrong-tab-namespace` rule that detects and fixes incorrect `Tab` component namespace imports in Filament v4 projects.

When Filament form code is generated with tabs, the wrong namespace is often used for the `Tab` component (`Filament\Schemas\Components\Tab` instead of `Filament\Schemas\Components\Tabs\Tab`), causing class-not-found errors.

This rule:
- Detects wrong Filament `Tab` imports (e.g. `Filament\Schemas\Components\Tab`, `Filament\Forms\Components\Tab`, `Filament\Forms\Components\Tabs\Tab`)
- Detects v3-style `Tabs\Tab::make()` inline usage and rewrites it to `Tab::make()` with the correct import
- Adds missing `Tab` import when `Tab::make()` is used without one
- Ignores non-Filament `Tab` imports (e.g. `App\Models\Tab`)
- All violations are auto-fixable

## Before

```php
<?php

use Filament\Schemas\Components\Tab; // Wrong namespace

class UserResource
{
    public function form(): void
    {
        Tab::make('Settings');
    }
}
```

Or using the v3-style inline reference:

```php
<?php

use Filament\Schemas\Components\Tabs;

class UserResource
{
    public function form(): void
    {
        Tabs\Tab::make('Settings'); // v3-style usage
    }
}
```

## After

```php
<?php

use Filament\Schemas\Components\Tabs\Tab; // Correct namespace

class UserResource
{
    public function form(): void
    {
        Tab::make('Settings');
    }
}
```

## Test plan

- [x] Detects wrong `Filament\Schemas\Components\Tab` import
- [x] Detects wrong `Filament\Forms\Components\Tab` import
- [x] Detects wrong `Filament\Forms\Components\Tabs\Tab` import
- [x] Detects v3-style `Tabs\Tab::make()` usage
- [x] Adds missing `Tab` import when `Tab::make()` used without one
- [x] Passes with correct `Filament\Schemas\Components\Tabs\Tab` import
- [x] Ignores non-Filament `Tab` imports
- [x] All violations are auto-fixable

Resolves #15 