### PR TITLE
Don't flag Action::make() inside ActionGroup in toolbarActions in `action-in-bulk-action-group` rule

### DIFF
--- a/src/Rules/ActionInBulkActionGroupRule.php
+++ b/src/Rules/ActionInBulkActionGroupRule.php
@@ -87,7 +87,22 @@ class ActionInBulkActionGroupRule implements FixableRule
                     }
                 }
 
-                // Check Action::make() directly inside toolbarActions (not in BulkActionGroup)
+                // Exclude Action::make() inside ActionGroup::make() (not a BulkActionGroup)
+                $actionGroups = $nodeFinder->find($arg, function (Node $n) {
+                    return $n instanceof StaticCall
+                        && $n->class instanceof Name
+                        && class_basename($n->class->toString()) === 'ActionGroup'
+                        && $n->name instanceof Identifier
+                        && $n->name->name === 'make';
+                });
+
+                foreach ($actionGroups as $actionGroup) {
+                    foreach ($nodeFinder->find($actionGroup, $isActionMake) as $actionCall) {
+                        $reported[$actionCall->class->getStartFilePos()] = true;
+                    }
+                }
+
+                // Check Action::make() directly inside toolbarActions (not in BulkActionGroup or ActionGroup)
                 $actionCalls = $nodeFinder->find($arg, $isActionMake);
 
                 foreach ($actionCalls as $actionCall) {

--- a/tests/Rules/ActionInBulkActionGroupRuleTest.php
+++ b/tests/Rules/ActionInBulkActionGroupRuleTest.php
@@ -364,6 +364,34 @@ PHP;
     expect($fixedCode)->toContain('use Filament\Actions\BulkAction;');
 });
 
+it('does not flag Action::make() inside ActionGroup::make() within toolbarActions', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Actions\ActionGroup;
+use Filament\Tables\Table;
+
+class TestResource
+{
+    public function table(Table $table): Table
+    {
+        return $table
+            ->toolbarActions([
+                ActionGroup::make([
+                    Action::make('approve')
+                        ->label('Approve'),
+                ]),
+            ]);
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new ActionInBulkActionGroupRule, $code);
+
+    $this->assertNoViolations($violations);
+});
+
 it('detects Action::make() in a non-table method with Table type-hinted parameter', function () {
     $code = <<<'PHP'
 <?php


### PR DESCRIPTION
## Fix: False positive for `Action::make()` inside `ActionGroup::make()` in `toolbarActions()`

Fixes #32.

The `action-in-bulk-action-group` rule was incorrectly flagging `Action::make()` calls nested inside a plain `ActionGroup::make()` within `toolbarActions()`. Only actions inside `BulkActionGroup::make()` (or directly in `toolbarActions()` with no group) should be flagged.

### Before

The following valid code would trigger a false positive:

```php
->toolbarActions([
    ActionGroup::make([
        Action::make('approve')->label('Approve'),
    ]),
])
```

```
✗ action-in-bulk-action-group (Best Practices)
  Line 174: `Action::make()` is used inside `toolbarActions()`. Use `BulkAction::make()` instead.
```

### After

`Action::make()` inside `ActionGroup::make()` is now correctly ignored. Only these two cases are still flagged:

**1. `Action::make()` inside `BulkActionGroup::make()`** — should be `BulkAction::make()`

```php
// ✗ flagged
->toolbarActions([
    BulkActionGroup::make([
        Action::make('approve'),
    ]),
])
```

**2. `Action::make()` directly in `toolbarActions()`** — should be `BulkAction::make()`

```php
// ✗ flagged
->toolbarActions([
    Action::make('approve'),
])
```

**3. `Action::make()` inside `ActionGroup::make()`** — now correctly passes

```php
// ✓ no violation
->toolbarActions([
    ActionGroup::make([
        Action::make('approve'),
    ]),
])
```