### PR TITLE
Fix `enabled: false` config having no effect when running `vendor/bin/filacheck`

### DIFF
--- a/bin/filacheck
+++ b/bin/filacheck
@@ -142,12 +142,15 @@ $scanner = new ResourceScanner();
 
 $registry = new RuleRegistry();
 
-$registry->register(FilacheckServiceProvider::rules());
+$registry->register(FilacheckServiceProvider::cliRules());
 
 // Pro rules (auto-detected if installed)
 $proProvider = 'FilacheckPro\\FilacheckProServiceProvider';
 if (class_exists($proProvider)) {
-    $registry->register($proProvider::rules());
+    $rules = method_exists($proProvider, 'cliRules')
+        ? $proProvider::cliRules()
+        : $proProvider::rules();
+    $registry->register($rules);
 }
 
 foreach ($registry->all() as $rule) {

--- a/src/FilacheckServiceProvider.php
+++ b/src/FilacheckServiceProvider.php
@@ -50,6 +50,19 @@ class FilacheckServiceProvider extends ServiceProvider
     }
 
     /** @return array<class-string<Rule>> */
+    public static function cliRules(): array
+    {
+        $configPath = getcwd().'/config/filacheck.php';
+        $config = file_exists($configPath) ? require $configPath : [];
+
+        return array_values(array_filter(static::rules(), function (string $ruleClass) use ($config): bool {
+            $name = (new $ruleClass)->name();
+
+            return (bool) ($config[$name]['enabled'] ?? true);
+        }));
+    }
+
+    /** @return array<class-string<Rule>> */
     public static function rules(): array
     {
         return [

--- a/tests/Support/RuleRegistryTest.php
+++ b/tests/Support/RuleRegistryTest.php
@@ -77,3 +77,64 @@ it('registers all rules from FilacheckServiceProvider', function () {
             \Filacheck\Rules\DeprecatedGetTableQueryRule::class,
     ]);
 });
+
+it('cliRules returns all rules when no config file exists', function () {
+    $originalDir = getcwd();
+    $tempDir = sys_get_temp_dir().'/filacheck-test-'.uniqid();
+    mkdir($tempDir);
+
+    try {
+        chdir($tempDir);
+        $rules = FilacheckServiceProvider::cliRules();
+
+        expect($rules)->toHaveCount(count(FilacheckServiceProvider::rules()));
+    } finally {
+        chdir($originalDir);
+        rmdir($tempDir);
+    }
+});
+
+it('cliRules excludes rules disabled in config', function () {
+    $originalDir = getcwd();
+    $tempDir = sys_get_temp_dir().'/filacheck-test-'.uniqid();
+    mkdir($tempDir.'/config', 0755, true);
+
+    file_put_contents($tempDir.'/config/filacheck.php', "<?php\nreturn [\n    'deprecated-reactive' => ['enabled' => false],\n    'deprecated-action-form' => ['enabled' => false],\n];\n");
+
+    try {
+        chdir($tempDir);
+        $rules = FilacheckServiceProvider::cliRules();
+
+        expect($rules)
+            ->not->toContain(\Filacheck\Rules\DeprecatedReactiveRule::class)
+            ->not->toContain(\Filacheck\Rules\DeprecatedActionFormRule::class)
+            ->toHaveCount(count(FilacheckServiceProvider::rules()) - 2);
+    } finally {
+        chdir($originalDir);
+        unlink($tempDir.'/config/filacheck.php');
+        rmdir($tempDir.'/config');
+        rmdir($tempDir);
+    }
+});
+
+it('cliRules keeps rules that are explicitly enabled in config', function () {
+    $originalDir = getcwd();
+    $tempDir = sys_get_temp_dir().'/filacheck-test-'.uniqid();
+    mkdir($tempDir.'/config', 0755, true);
+
+    file_put_contents($tempDir.'/config/filacheck.php', "<?php\nreturn [\n    'deprecated-reactive' => ['enabled' => true],\n];\n");
+
+    try {
+        chdir($tempDir);
+        $rules = FilacheckServiceProvider::cliRules();
+
+        expect($rules)
+            ->toContain(\Filacheck\Rules\DeprecatedReactiveRule::class)
+            ->toHaveCount(count(FilacheckServiceProvider::rules()));
+    } finally {
+        chdir($originalDir);
+        unlink($tempDir.'/config/filacheck.php');
+        rmdir($tempDir.'/config');
+        rmdir($tempDir);
+    }
+});


### PR DESCRIPTION
## Problem

Setting a rule to `enabled: false` in `config/filacheck.php` (or `config/filacheck-pro.php` for Pro) did not prevent it from running. The CLI (`bin/filacheck`) called `FilacheckServiceProvider::rules()` directly — a static method that returns all rules with no filtering. The actual filtering logic lives in `boot()`, which is never called in the CLI context because no Laravel application is bootstrapped. The `catch (\Throwable)` fallback silently returned `true` for every rule, so all rules always ran regardless of config.

## Fix

Added a `cliRules()` static method to `FilacheckServiceProvider` (and `FilacheckProServiceProvider` in the Pro package) that reads the config file directly from the project root via `getcwd()` — no Laravel container required. The CLI was updated to call `cliRules()` instead of `rules()` for both providers, so disabled rules are now correctly excluded. The existing `boot()` filtering is unchanged and continues to work correctly in the Laravel app context via the `config()` helper.