### PR TITLE
Prep structured agent output and implement agentFix() on free rules

### DIFF
--- a/bin/filacheck
+++ b/bin/filacheck
@@ -4,13 +4,14 @@
 declare(strict_types=1);
 
 use Filacheck\Fixer\CodeFixer;
-use Filacheck\Reporting\StandaloneReporter;
+use Filacheck\Reporting\ReporterFactory;
 use Filacheck\FilacheckServiceProvider;
 use Filacheck\Rules\BladeRule;
 use Filacheck\Rules\ExtraPathRule;
 use Filacheck\Scanner\ResourceScanner;
 use Filacheck\Support\GitDirtyFiles;
 use Filacheck\Support\RuleRegistry;
+use Filacheck\Support\RunContext;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
 // Autoload handling for different installation contexts
@@ -131,26 +132,43 @@ if (! $dirty && ! is_dir($path) && ! is_file($path)) {
     exit(1);
 }
 
-if ($dirty) {
-    $output->writeln('Scanning dirty files...');
-} else {
-    $output->writeln("Scanning: <fg=gray>{$path}</>");
-}
-$output->writeln('');
-
 $scanner = new ResourceScanner();
 
 $registry = new RuleRegistry();
 
 $registry->register(FilacheckServiceProvider::cliRules());
 
-// Pro rules (auto-detected if installed)
+// Pro rules (auto-detected if installed). Pro's cliRules() may also call
+// RunContext::markAgent() and ReporterFactory::override() as a side effect
+// when an AI coding agent is detected (pao-style).
 $proProvider = 'FilacheckPro\\FilacheckProServiceProvider';
 if (class_exists($proProvider)) {
     $rules = method_exists($proProvider, 'cliRules')
         ? $proProvider::cliRules()
         : $proProvider::rules();
     $registry->register($rules);
+}
+
+// In agent mode, force --fix so CodeFixer applies all auto-fixable issues
+// with byte-precise positions before any structured reporter (e.g.
+// JsonReporter) emits output. This avoids handing the agent ambiguous
+// search/replace strings for fixes the tool can already apply itself.
+if (RunContext::isAgent()) {
+    $fix = true;
+}
+
+// Progress text goes to stderr so stdout stays clean for parseable
+// reporter output (e.g. JsonReporter when an AI agent is detected). In
+// agent mode the progress chatter is suppressed entirely so the agent
+// gets a clean single-line JSON document on stdout and nothing else.
+if (! RunContext::isAgent()) {
+    $progress = $output->getErrorOutput();
+    if ($dirty) {
+        $progress->writeln('Scanning dirty files...');
+    } else {
+        $progress->writeln("Scanning: <fg=gray>{$path}</>");
+    }
+    $progress->writeln('');
 }
 
 foreach ($registry->all() as $rule) {
@@ -255,7 +273,7 @@ if ($dirty) {
     }
 }
 
-$reporter = new StandaloneReporter($output, $verbose);
+$reporter = ReporterFactory::make($output, $verbose);
 
 if ($fix && count($violations) > 0) {
     $fixer = new CodeFixer();

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "php": "^8.2",
         "filament/filament": "^4.0|^5.0",
         "nikic/php-parser": "^5.0",
-        "symfony/console": "^6.0|^7.0|^8.0"
+        "symfony/console": "^6.0|^7.0|^8.0",
+        "symfony/process": "^6.0|^7.0|^8.0"
     },
     "require-dev": {
         "pestphp/pest": "^3.0|^4.0",

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -1,0 +1,3 @@
+## laraveldaily/filacheck
+
+- After you have created/modified any files in `app/Filament` folder, you must run `vendor/bin/filacheck --fix`, to ensure there is no deprecated Filament code. Reported not fixed issues MUST be fixed before continuing.

--- a/src/Fixer/CodeFixer.php
+++ b/src/Fixer/CodeFixer.php
@@ -3,6 +3,7 @@
 namespace Filacheck\Fixer;
 
 use Filacheck\Support\Violation;
+use Symfony\Component\Process\Process;
 
 class CodeFixer
 {
@@ -11,6 +12,9 @@ class CodeFixer
 
     /** @var array<string, array<int, array{line: int, column: int, from: string, to: string}>> */
     private array $previews = [];
+
+    /** @var array<int, array{command: string, cwd: string, status: string, output: string, violations: int}> */
+    private array $commands = [];
 
     private int $totalFixed = 0;
 
@@ -25,21 +29,27 @@ class CodeFixer
      *     skipped: int,
      *     byFile: array<string, array{fixed: int, skipped: int}>,
      *     dryRun: bool,
-     *     previews: array<string, array<int, array{line: int, column: int, from: string, to: string}>>
+     *     previews: array<string, array<int, array{line: int, column: int, from: string, to: string}>>,
+     *     commands: array<int, array{command: string, cwd: string, status: string, output: string, violations: int}>
      * }
      */
     public function fix(array $violations, bool $createBackup = false, bool $dryRun = false): array
     {
         $this->results = [];
         $this->previews = [];
+        $this->commands = [];
         $this->totalFixed = 0;
         $this->totalSkipped = 0;
 
-        $violationsByFile = $this->groupByFile($violations);
+        [$commandViolations, $textViolations] = $this->partition($violations);
+
+        $violationsByFile = $this->groupByFile($textViolations);
 
         foreach ($violationsByFile as $file => $fileViolations) {
             $this->fixFile($file, $fileViolations, $createBackup, $dryRun);
         }
+
+        $this->fixCommands($commandViolations, $dryRun);
 
         return [
             'fixed' => $this->totalFixed,
@@ -47,7 +57,33 @@ class CodeFixer
             'byFile' => $this->results,
             'dryRun' => $dryRun,
             'previews' => $this->previews,
+            'commands' => $this->commands,
         ];
+    }
+
+    /**
+     * Split violations into command-style (run a shell command) and text-style
+     * (byte-level replacement). A violation is command-style when it carries
+     * a non-null fixCommand; otherwise it falls through to the text path so
+     * all existing fixable rules keep behaving identically.
+     *
+     * @param  Violation[]  $violations
+     * @return array{0: Violation[], 1: Violation[]}
+     */
+    private function partition(array $violations): array
+    {
+        $command = [];
+        $text = [];
+
+        foreach ($violations as $violation) {
+            if ($violation->fixCommand !== null) {
+                $command[] = $violation;
+            } else {
+                $text[] = $violation;
+            }
+        }
+
+        return [$command, $text];
     }
 
     /**
@@ -131,5 +167,121 @@ class CodeFixer
         $fixed = count($fixableViolations);
         $this->totalFixed += $fixed;
         $this->results[$file] = ['fixed' => $fixed, 'skipped' => $skipped];
+    }
+
+    /**
+     * Execute command-style fix violations. Multiple violations carrying the
+     * same (fixCommand, fixCommandCwd) tuple collapse into a single execution
+     * but still each contribute to the fixed/skipped counters so the user
+     * sees the same scale they'd see with text-style fixes. Refuses to run
+     * when the resolved cwd does not contain an `artisan` file — that almost
+     * always indicates a misconfigured rule passing the wrong basePath.
+     *
+     * @param  Violation[]  $violations
+     */
+    private function fixCommands(array $violations, bool $dryRun): void
+    {
+        if ($violations === []) {
+            return;
+        }
+
+        // Group originating violations by their (command, cwd) tuple so a
+        // command runs once but counts once per blade file that triggered it.
+        $groups = [];
+
+        foreach ($violations as $violation) {
+            if (! $violation->isFixable || $violation->fixCommand === null) {
+                $this->totalSkipped++;
+
+                continue;
+            }
+
+            $cwd = $violation->fixCommandCwd ?? (getcwd() ?: '');
+            $key = $violation->fixCommand . '|' . $cwd;
+
+            if (! isset($groups[$key])) {
+                $groups[$key] = [
+                    'command' => $violation->fixCommand,
+                    'cwd' => $cwd,
+                    'count' => 0,
+                ];
+            }
+
+            $groups[$key]['count']++;
+        }
+
+        foreach ($groups as $group) {
+            $command = $group['command'];
+            $cwd = $group['cwd'];
+            $count = $group['count'];
+
+            if ($cwd === '' || ! is_dir($cwd) || ! is_file($cwd . DIRECTORY_SEPARATOR . 'artisan')) {
+                $this->commands[] = [
+                    'command' => $command,
+                    'cwd' => $cwd,
+                    'status' => 'failed',
+                    'output' => 'Refusing to run: no artisan file found in working directory.',
+                    'violations' => $count,
+                ];
+                $this->totalSkipped += $count;
+
+                continue;
+            }
+
+            if ($dryRun) {
+                $this->commands[] = [
+                    'command' => $command,
+                    'cwd' => $cwd,
+                    'status' => 'would-run',
+                    'output' => '',
+                    'violations' => $count,
+                ];
+                $this->totalFixed += $count;
+
+                continue;
+            }
+
+            $process = Process::fromShellCommandline($command, $cwd, null, null, 60);
+
+            try {
+                $process->run();
+            } catch (\Throwable $e) {
+                $this->commands[] = [
+                    'command' => $command,
+                    'cwd' => $cwd,
+                    'status' => 'failed',
+                    'output' => $e->getMessage(),
+                    'violations' => $count,
+                ];
+                $this->totalSkipped += $count;
+
+                continue;
+            }
+
+            if ($process->isSuccessful()) {
+                $this->commands[] = [
+                    'command' => $command,
+                    'cwd' => $cwd,
+                    'status' => 'ran',
+                    'output' => trim($process->getOutput()),
+                    'violations' => $count,
+                ];
+                $this->totalFixed += $count;
+            } else {
+                $output = trim($process->getErrorOutput());
+                if ($output === '') {
+                    $output = trim($process->getOutput());
+                }
+
+                $this->commands[] = [
+                    'command' => $command,
+                    'cwd' => $cwd,
+                    'status' => 'failed',
+                    'output' => $output,
+                    'violations' => $count,
+                ];
+                $this->totalSkipped += $count;
+            }
+        }
     }
 }

--- a/src/Reporting/ConsoleReporter.php
+++ b/src/Reporting/ConsoleReporter.php
@@ -7,7 +7,7 @@ use Filacheck\Rules\Rule;
 use Filacheck\Support\Violation;
 use Illuminate\Console\Command;
 
-class ConsoleReporter
+class ConsoleReporter implements ReporterInterface
 {
     public function __construct(
         private Command $command,

--- a/src/Reporting/ReporterFactory.php
+++ b/src/Reporting/ReporterFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Filacheck\Reporting;
+
+use Closure;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class ReporterFactory
+{
+    private static ?Closure $resolver = null;
+
+    /**
+     * Register a custom reporter factory.
+     *
+     * The closure receives ($output, $verbose) and must return a
+     * ReporterInterface. Used by FilaCheck-Pro to install JsonReporter
+     * when an AI agent is detected at runtime.
+     */
+    public static function override(Closure $resolver): void
+    {
+        self::$resolver = $resolver;
+    }
+
+    public static function reset(): void
+    {
+        self::$resolver = null;
+    }
+
+    public static function make(OutputInterface $output, bool $verbose = false): ReporterInterface
+    {
+        if (self::$resolver !== null) {
+            $reporter = (self::$resolver)($output, $verbose);
+
+            if ($reporter instanceof ReporterInterface) {
+                return $reporter;
+            }
+        }
+
+        return new StandaloneReporter($output, $verbose);
+    }
+}

--- a/src/Reporting/ReporterInterface.php
+++ b/src/Reporting/ReporterInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Filacheck\Reporting;
+
+use Filacheck\Rules\Rule;
+use Filacheck\Support\Violation;
+
+interface ReporterInterface
+{
+    /**
+     * @param  Rule[]  $rules
+     * @param  Violation[]  $violations
+     */
+    public function report(array $rules, array $violations): void;
+
+    /**
+     * @param  Rule[]  $rules
+     * @param  Violation[]  $violations
+     * @param  array<string, mixed>  $fixResults
+     */
+    public function reportWithFixes(array $rules, array $violations, array $fixResults): void;
+}

--- a/src/Reporting/StandaloneReporter.php
+++ b/src/Reporting/StandaloneReporter.php
@@ -8,7 +8,7 @@ use Filacheck\Rules\Rule;
 use Filacheck\Support\Violation;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class StandaloneReporter
+class StandaloneReporter implements ReporterInterface
 {
     use HandlesDryRunPreviews;
 

--- a/src/Rules/ActionInBulkActionGroupRule.php
+++ b/src/Rules/ActionInBulkActionGroupRule.php
@@ -16,7 +16,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\NodeFinder;
 
-class ActionInBulkActionGroupRule implements FixableRule
+class ActionInBulkActionGroupRule implements FixableRule, ProvidesAgentFix
 {
     use AddsImport;
     use CalculatesLineNumbers;
@@ -140,6 +140,20 @@ class ActionInBulkActionGroupRule implements FixableRule
         }
 
         return false;
+    }
+
+    public function agentFix(Violation $violation): mixed
+    {
+        return [
+            'instructions' => 'Replace `Action::make()` with `BulkAction::make()` whenever it appears inside `toolbarActions()` (directly or wrapped in a `BulkActionGroup`).',
+            'next_steps' => [
+                'Rename the `Action::make()` static call to `BulkAction::make()` — the rest of the chain stays the same.',
+                'Add `use Filament\Actions\BulkAction;` to the file (the rule emits a separate import violation for this when needed).',
+                'Do not rewrite `Action::make()` calls inside an `ActionGroup::make()` — those still belong to the per-row action group and are not bulk actions.',
+                'Single-record actions belong in `recordActions()`, not `toolbarActions()`. If the call was placed in the wrong slot, move it instead of changing its class.',
+            ],
+            'docs' => $this->filamentDocsUrl('tables/actions#bulk-actions'),
+        ];
     }
 
     private function buildActionViolation(StaticCall $actionCall, Context $context): Violation

--- a/src/Rules/DeprecatedActionFormRule.php
+++ b/src/Rules/DeprecatedActionFormRule.php
@@ -14,7 +14,7 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 
-class DeprecatedActionFormRule implements FixableRule
+class DeprecatedActionFormRule implements FixableRule, ProvidesAgentFix
 {
     use CalculatesLineNumbers;
     use ResolvesFilamentDocsUrl;
@@ -77,6 +77,19 @@ class DeprecatedActionFormRule implements FixableRule
                 endPos: $endPos,
                 replacement: 'schema',
             ),
+        ];
+    }
+
+    public function agentFix(Violation $violation): mixed
+    {
+        return [
+            'instructions' => 'Rename the deprecated `form()` method on actions to `schema()`.',
+            'next_steps' => [
+                'Replace `->form([...])` with `->schema([...])` on the action. The array of components is unchanged.',
+                'Only apply this rename when the chain originates from an action class (e.g. `CreateAction`, `EditAction`, `Action`) or inside a class that extends one.',
+                'Do not rename `form()` on Livewire components or table configurations — those are unrelated to this deprecation.',
+            ],
+            'docs' => $this->filamentDocsUrl('actions'),
         ];
     }
 

--- a/src/Rules/DeprecatedBulkActionsRule.php
+++ b/src/Rules/DeprecatedBulkActionsRule.php
@@ -14,7 +14,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\NodeFinder;
 
-class DeprecatedBulkActionsRule implements FixableRule
+class DeprecatedBulkActionsRule implements FixableRule, ProvidesAgentFix
 {
     use CalculatesLineNumbers;
     use ResolvesFilamentDocsUrl;
@@ -67,6 +67,18 @@ class DeprecatedBulkActionsRule implements FixableRule
         }
 
         return $violations;
+    }
+
+    public function agentFix(Violation $violation): mixed
+    {
+        return [
+            'instructions' => 'Rename the deprecated `bulkActions()` method on the table configuration to `toolbarActions()`.',
+            'next_steps' => [
+                'Replace `->bulkActions([...])` with `->toolbarActions([...])` inside the `table(Table $table)` method.',
+                'The array contents are unchanged — bulk actions still use `BulkAction::make()` or `BulkActionGroup::make()`.',
+            ],
+            'docs' => $this->filamentDocsUrl('tables/actions#record-actions'),
+        ];
     }
 
     private function hasTableParameter(ClassMethod $node): bool

--- a/src/Rules/DeprecatedEmptyLabelRule.php
+++ b/src/Rules/DeprecatedEmptyLabelRule.php
@@ -16,7 +16,7 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
 
-class DeprecatedEmptyLabelRule implements FixableRule
+class DeprecatedEmptyLabelRule implements FixableRule, ProvidesAgentFix
 {
     use CalculatesLineNumbers;
     use ResolvesClassBasename;
@@ -100,6 +100,19 @@ class DeprecatedEmptyLabelRule implements FixableRule
                 endPos: $endPos,
                 replacement: 'hiddenLabel()',
             ),
+        ];
+    }
+
+    public function agentFix(Violation $violation): mixed
+    {
+        return [
+            'instructions' => 'Stop using `label(\'\')` to hide labels — use the dedicated helper instead (`hiddenLabel()` for fields, `iconButton()` for actions).',
+            'next_steps' => [
+                'For action chains (any class whose name ends in `Action`), replace `->label(\'\')` with `->iconButton()` so the trigger renders as an icon-only button.',
+                'For everything else (form fields, schema components), replace `->label(\'\')` with `->hiddenLabel()`.',
+                'Do not apply this fix to table column chains — columns do not expose `hiddenLabel()` and the rule already skips them.',
+            ],
+            'docs' => $this->filamentDocsUrl('forms/overview#hiding-a-field’s-label'),
         ];
     }
 

--- a/src/Rules/DeprecatedFilterFormRule.php
+++ b/src/Rules/DeprecatedFilterFormRule.php
@@ -14,7 +14,7 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 
-class DeprecatedFilterFormRule implements FixableRule
+class DeprecatedFilterFormRule implements FixableRule, ProvidesAgentFix
 {
     use CalculatesLineNumbers;
     use ResolvesFilamentDocsUrl;
@@ -69,6 +69,18 @@ class DeprecatedFilterFormRule implements FixableRule
                 endPos: $endPos,
                 replacement: 'schema',
             ),
+        ];
+    }
+
+    public function agentFix(Violation $violation): mixed
+    {
+        return [
+            'instructions' => 'Rename the deprecated `form()` method on filters to `schema()`.',
+            'next_steps' => [
+                'Replace `->form([...])` with `->schema([...])` on the filter. The array of components is unchanged.',
+                'Only apply this rename when the chain originates from a filter class (e.g. `Filter`, `SelectFilter`, `TernaryFilter`, `QueryBuilder`) or inside a class that extends one.',
+            ],
+            'docs' => $this->filamentDocsUrl('tables/filters/custom'),
         ];
     }
 

--- a/src/Rules/DeprecatedFormsGetRule.php
+++ b/src/Rules/DeprecatedFormsGetRule.php
@@ -13,7 +13,7 @@ use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\Use_;
 
-class DeprecatedFormsGetRule implements FixableRule
+class DeprecatedFormsGetRule implements FixableRule, ProvidesAgentFix
 {
     use AddsImport;
     use CalculatesLineNumbers;
@@ -106,5 +106,18 @@ class DeprecatedFormsGetRule implements FixableRule
         }
 
         return $violations;
+    }
+
+    public function agentFix(Violation $violation): mixed
+    {
+        return [
+            'instructions' => 'Migrate from the deprecated `Filament\Forms\Get` to `Filament\Schemas\Components\Utilities\Get`.',
+            'next_steps' => [
+                'Replace the import `use Filament\Forms\Get;` with `use Filament\Schemas\Components\Utilities\Get;`.',
+                'Change any closure parameter typed as `callable $get` (when the variable is `$get`) to `Get $get` so state lookups stay type-safe.',
+                'If several files import the old namespace, repeat the rename in every file — each is its own violation.',
+            ],
+            'docs' => $this->filamentDocsUrl('forms/overview#injecting-the-state-of-another-field'),
+        ];
     }
 }

--- a/src/Rules/DeprecatedFormsSetRule.php
+++ b/src/Rules/DeprecatedFormsSetRule.php
@@ -13,7 +13,7 @@ use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\Use_;
 
-class DeprecatedFormsSetRule implements FixableRule
+class DeprecatedFormsSetRule implements FixableRule, ProvidesAgentFix
 {
     use AddsImport;
     use CalculatesLineNumbers;
@@ -106,5 +106,18 @@ class DeprecatedFormsSetRule implements FixableRule
         }
 
         return $violations;
+    }
+
+    public function agentFix(Violation $violation): mixed
+    {
+        return [
+            'instructions' => 'Migrate from the deprecated `Filament\Forms\Set` to `Filament\Schemas\Components\Utilities\Set`.',
+            'next_steps' => [
+                'Replace the import `use Filament\Forms\Set;` with `use Filament\Schemas\Components\Utilities\Set;`.',
+                'Change any closure parameter typed as `callable $set` (when the variable is `$set`) to `Set $set` so state mutations stay type-safe.',
+                'If several files import the old namespace, repeat the rename in every file — each is its own violation.',
+            ],
+            'docs' => $this->filamentDocsUrl('forms/overview#setting-the-state-of-another-field'),
+        ];
     }
 }

--- a/src/Rules/DeprecatedGetTableQueryRule.php
+++ b/src/Rules/DeprecatedGetTableQueryRule.php
@@ -17,7 +17,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\NodeFinder;
 
-class DeprecatedGetTableQueryRule implements FixableRule
+class DeprecatedGetTableQueryRule implements FixableRule, ProvidesAgentFix
 {
     use AddsImport;
     use CalculatesLineNumbers;
@@ -147,6 +147,20 @@ class DeprecatedGetTableQueryRule implements FixableRule
         );
 
         return $violations;
+    }
+
+    public function agentFix(Violation $violation): mixed
+    {
+        return [
+            'instructions' => 'Move the query from the deprecated `getTableQuery()` method into a `->query()` call inside `table(Table $table)`.',
+            'next_steps' => [
+                'Inside the existing `table(Table $table)` method, chain `->query(fn (): Builder => /* the original return expression */)` directly off `$table`.',
+                'Add `use Illuminate\Database\Eloquent\Builder;` at the top of the file if it is not already imported.',
+                'Delete the `getTableQuery()` method completely — it is no longer wired up.',
+                'If the body of `getTableQuery()` is more than a single return statement, lift the logic into the closure manually rather than relying on the auto-fix.',
+            ],
+            'docs' => $this->filamentDocsUrl('components/table'),
+        ];
     }
 
     private function findMethod(Class_ $class, string $name): ?ClassMethod

--- a/src/Rules/DeprecatedImageColumnSizeRule.php
+++ b/src/Rules/DeprecatedImageColumnSizeRule.php
@@ -14,7 +14,7 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 
-class DeprecatedImageColumnSizeRule implements FixableRule
+class DeprecatedImageColumnSizeRule implements FixableRule, ProvidesAgentFix
 {
     use CalculatesLineNumbers;
     use ResolvesFilamentDocsUrl;
@@ -62,6 +62,18 @@ class DeprecatedImageColumnSizeRule implements FixableRule
                 endPos: $endPos,
                 replacement: 'imageSize',
             ),
+        ];
+    }
+
+    public function agentFix(Violation $violation): mixed
+    {
+        return [
+            'instructions' => 'Rename the deprecated `size()` method on `ImageColumn` to `imageSize()`.',
+            'next_steps' => [
+                'Replace `->size(...)` with `->imageSize(...)` on the `ImageColumn`. Arguments are unchanged.',
+                'Only apply this rename on `ImageColumn` chains — `size()` is still valid on other columns like `TextColumn`.',
+            ],
+            'docs' => $this->filamentDocsUrl('tables/columns/image#customizing-the-size'),
         ];
     }
 

--- a/src/Rules/DeprecatedMutateFormDataUsingRule.php
+++ b/src/Rules/DeprecatedMutateFormDataUsingRule.php
@@ -4,15 +4,17 @@ namespace Filacheck\Rules;
 
 use Filacheck\Enums\RuleCategory;
 use Filacheck\Rules\Concerns\CalculatesLineNumbers;
+use Filacheck\Rules\Concerns\ResolvesFilamentDocsUrl;
 use Filacheck\Support\Context;
 use Filacheck\Support\Violation;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Identifier;
 
-class DeprecatedMutateFormDataUsingRule implements FixableRule
+class DeprecatedMutateFormDataUsingRule implements FixableRule, ProvidesAgentFix
 {
     use CalculatesLineNumbers;
+    use ResolvesFilamentDocsUrl;
     public function name(): string
     {
         return 'deprecated-mutate-form-data-using';
@@ -53,6 +55,18 @@ class DeprecatedMutateFormDataUsingRule implements FixableRule
                 endPos: $endPos,
                 replacement: 'mutateDataUsing',
             ),
+        ];
+    }
+
+    public function agentFix(Violation $violation): mixed
+    {
+        return [
+            'instructions' => 'Rename the deprecated `mutateFormDataUsing()` callback to `mutateDataUsing()`.',
+            'next_steps' => [
+                'Replace the method name `mutateFormDataUsing` with `mutateDataUsing`. The closure signature is unchanged.',
+                'Check every action chain in the file — this rule only reports one occurrence per node, but the same rename applies everywhere the deprecated name is used.',
+            ],
+            'docs' => $this->filamentDocsUrl('actions/overview'),
         ];
     }
 }

--- a/src/Rules/DeprecatedPlaceholderRule.php
+++ b/src/Rules/DeprecatedPlaceholderRule.php
@@ -13,7 +13,7 @@ use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 
-class DeprecatedPlaceholderRule implements Rule
+class DeprecatedPlaceholderRule implements ProvidesAgentFix, Rule
 {
     use CalculatesLineNumbers;
     use ResolvesClassBasename;
@@ -62,6 +62,20 @@ class DeprecatedPlaceholderRule implements Rule
                 line: $this->getLineFromPosition($context->code, $node->name->getStartFilePos()),
                 suggestion: 'Use `TextEntry::make()->state()` instead. See: ' . $this->filamentDocsUrl('infolists/overview#setting-the-state-of-an-entry'),
             ),
+        ];
+    }
+
+    public function agentFix(Violation $violation): mixed
+    {
+        return [
+            'instructions' => 'Replace the deprecated `Placeholder::make()` component with `TextEntry::make()->state(...)`.',
+            'next_steps' => [
+                'Swap `Placeholder::make($name)->content($value)` for `TextEntry::make($name)->state($value)`.',
+                'Add the import `use Filament\Infolists\Components\TextEntry;` if it is not already present.',
+                'If the placeholder was inside a form schema rather than an infolist, move the field into the corresponding infolist `schema()` — `TextEntry` lives in the infolist namespace.',
+                'This rule has no auto-fix; the rename must be done by hand.',
+            ],
+            'docs' => $this->filamentDocsUrl('infolists/overview#setting-the-state-of-an-entry'),
         ];
     }
 

--- a/src/Rules/DeprecatedReactiveRule.php
+++ b/src/Rules/DeprecatedReactiveRule.php
@@ -11,7 +11,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Identifier;
 
-class DeprecatedReactiveRule implements FixableRule
+class DeprecatedReactiveRule implements FixableRule, ProvidesAgentFix
 {
     use CalculatesLineNumbers;
     use ResolvesFilamentDocsUrl;
@@ -55,6 +55,18 @@ class DeprecatedReactiveRule implements FixableRule
                 endPos: $endPos,
                 replacement: 'live',
             ),
+        ];
+    }
+
+    public function agentFix(Violation $violation): mixed
+    {
+        return [
+            'instructions' => 'Replace the deprecated `reactive()` modifier with `live()`.',
+            'next_steps' => [
+                'Rename `->reactive()` to `->live()` on the field.',
+                'If you need debounced updates, use `->live(debounce: 500)`. If you only want to react on blur, use `->live(onBlur: true)`.',
+            ],
+            'docs' => $this->filamentDocsUrl('forms/overview#the-basics-of-reactivity'),
         ];
     }
 }

--- a/src/Rules/DeprecatedTestMethodsRule.php
+++ b/src/Rules/DeprecatedTestMethodsRule.php
@@ -5,6 +5,7 @@ namespace Filacheck\Rules;
 use Filacheck\Enums\RuleCategory;
 use Filacheck\Rules\Concerns\AddsImport;
 use Filacheck\Rules\Concerns\CalculatesLineNumbers;
+use Filacheck\Rules\Concerns\ResolvesFilamentDocsUrl;
 use Filacheck\Support\Context;
 use Filacheck\Support\Violation;
 use PhpParser\Node;
@@ -13,10 +14,11 @@ use PhpParser\Node\Identifier;
 
 use function is_string;
 
-class DeprecatedTestMethodsRule implements FixableRule, ExtraPathRule
+class DeprecatedTestMethodsRule implements FixableRule, ExtraPathRule, ProvidesAgentFix
 {
     use AddsImport;
     use CalculatesLineNumbers;
+    use ResolvesFilamentDocsUrl;
 
     /**
      * @var array<string, string|array{0: string, 1: string|array{0: string, 1: string}}>
@@ -281,5 +283,34 @@ class DeprecatedTestMethodsRule implements FixableRule, ExtraPathRule
     public function extraScanPaths(): array
     {
         return ['test', 'tests'];
+    }
+
+    public function agentFix(Violation $violation): mixed
+    {
+        $methodName = null;
+
+        if (preg_match('/`([A-Za-z0-9_]+)\(\)`/', $violation->message, $matches)) {
+            $methodName = $matches[1];
+        }
+
+        $replacement = null;
+
+        if ($methodName !== null && array_key_exists($methodName, $this->deprecatedMethods)) {
+            $deprecated = $this->deprecatedMethods[$methodName];
+            $replacement = is_string($deprecated) ? $deprecated : $deprecated[0];
+        }
+
+        return [
+            'instructions' => 'Replace the deprecated Filament v3 testing helper with its v4 equivalent.',
+            'deprecated_method' => $methodName,
+            'replacement' => $replacement,
+            'next_steps' => [
+                'Rename the test helper according to the v4 mapping. Most table/form helpers move to `TestAction::make(...)->table()` (or `->bulk()`, `->schemaComponent()`) wrappers.',
+                'When the replacement uses `TestAction::make(...)`, add `use Filament\Actions\Testing\TestAction;` to the test file (the rule emits a separate import violation for this when needed).',
+                'Helpers like `assertHasActionErrors` collapse to `assertHasFormErrors()` — the argument list is unchanged.',
+                'Some replacements (e.g. `callTableAction`, `assertTableActionHasIcon`) are not auto-fixable because they require argument restructuring; rewrite them by hand using the suggestion text.',
+            ],
+            'docs' => $this->filamentDocsUrl('testing'),
+        ];
     }
 }

--- a/src/Rules/DeprecatedUrlParametersRule.php
+++ b/src/Rules/DeprecatedUrlParametersRule.php
@@ -4,14 +4,16 @@ namespace Filacheck\Rules;
 
 use Filacheck\Enums\RuleCategory;
 use Filacheck\Rules\Concerns\CalculatesLineNumbers;
+use Filacheck\Rules\Concerns\ResolvesFilamentDocsUrl;
 use Filacheck\Support\Context;
 use Filacheck\Support\Violation;
 use PhpParser\Node;
 use PhpParser\Node\Scalar\String_;
 
-class DeprecatedUrlParametersRule implements FixableRule
+class DeprecatedUrlParametersRule implements FixableRule, ProvidesAgentFix
 {
     use CalculatesLineNumbers;
+    use ResolvesFilamentDocsUrl;
 
     private const RENAMED_PARAMETERS = [
         'activeRelationManager' => 'relation',
@@ -68,5 +70,18 @@ class DeprecatedUrlParametersRule implements FixableRule
         }
 
         return $violations;
+    }
+
+    public function agentFix(Violation $violation): mixed
+    {
+        return [
+            'instructions' => 'Rename the deprecated Livewire URL query-string parameter to its v4 equivalent.',
+            'next_steps' => [
+                'Rename the parameter inside the string literal: `activeRelationManager`→`relation`, `activeTab`→`tab`, `isTableReordering`→`reordering`, `tableFilters`→`filters`, `tableGrouping`→`grouping`, `tableGroupingDirection`→`groupingDirection`, `tableSearch`→`search`, `tableSort`→`sort`.',
+                'These parameter names also appear in the `#[Url]` attribute and `$queryString` arrays on Livewire components — keep the surrounding code intact, just swap the key.',
+                'Each occurrence is reported as its own violation so apply the fix to every match in the file.',
+            ],
+            'docs' => $this->filamentDocsUrl('resources/overview'),
+        ];
     }
 }

--- a/src/Rules/DeprecatedViewPropertyRule.php
+++ b/src/Rules/DeprecatedViewPropertyRule.php
@@ -4,13 +4,15 @@ namespace Filacheck\Rules;
 
 use Filacheck\Enums\RuleCategory;
 use Filacheck\Rules\Concerns\CalculatesLineNumbers;
+use Filacheck\Rules\Concerns\ResolvesFilamentDocsUrl;
 use Filacheck\Support\Context;
 use Filacheck\Support\Violation;
 use PhpParser\Node;
 
-class DeprecatedViewPropertyRule implements FixableRule
+class DeprecatedViewPropertyRule implements FixableRule, ProvidesAgentFix
 {
     use CalculatesLineNumbers;
+    use ResolvesFilamentDocsUrl;
 
     public function name(): string
     {
@@ -63,6 +65,19 @@ class DeprecatedViewPropertyRule implements FixableRule
                 endPos: $propVarStartPos,
                 replacement: 'protected string ',
             ),
+        ];
+    }
+
+    public function agentFix(Violation $violation): mixed
+    {
+        return [
+            'instructions' => 'Declare the `$view` property as `protected string $view` so Filament can resolve the view path correctly.',
+            'next_steps' => [
+                'Change the visibility, modifier, and type of the `$view` property to exactly `protected string $view = \'...\';`.',
+                'Do not make the property `static`, `public`, `private`, or untyped — Filament expects the protected-string shape.',
+                'If the value is computed at runtime, use a `getView()` method instead and remove the property.',
+            ],
+            'docs' => $this->filamentDocsUrl('schemas/overview'),
         ];
     }
 }

--- a/src/Rules/FixableRule.php
+++ b/src/Rules/FixableRule.php
@@ -5,10 +5,25 @@ namespace Filacheck\Rules;
 /**
  * Rules implementing this interface provide auto-fix data in Violation objects.
  *
- * Fixable rules must set these properties on Violations:
+ * Fixable violations come in two flavours; a violation must populate exactly one:
+ *
+ * Text replacement (in-place edit of the offending file):
  * - isFixable: true
  * - startPos: Character offset in file where fix starts
  * - endPos: Character offset in file where fix ends
  * - replacement: String to replace the matched content
+ *
+ * Command execution (run an external command from the project root, e.g. an
+ * artisan generator that scaffolds files outside the offending file):
+ * - isFixable: true
+ * - fixCommand: Shell command to run (e.g. "php artisan make:filament-theme admin --no-interaction")
+ * - fixCommandCwd: Absolute working directory to run it from (typically the
+ *   scanner-supplied project basePath). CodeFixer refuses to execute when this
+ *   directory does not contain an `artisan` file, as a guard against
+ *   misconfigured rules.
+ *
+ * CodeFixer dedupes command-style violations by (fixCommand, fixCommandCwd) so
+ * the same command never runs more than once per scan, regardless of how many
+ * Blade files trigger it.
  */
 interface FixableRule extends Rule {}

--- a/src/Rules/ProvidesAgentFix.php
+++ b/src/Rules/ProvidesAgentFix.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Filacheck\Rules;
+
+use Filacheck\Support\Violation;
+
+/**
+ * Optional rule extension. Rules implementing this interface can return
+ * a structured, agent-specific fix description for each violation they
+ * emit.
+ *
+ * Used by structured reporters (e.g. JsonReporter when an AI coding
+ * agent is detected) to give the agent a concrete, actionable plan
+ * instead of the human-readable suggestion. Has no effect on text
+ * reporters and is independent from FixableRule — a rule can be
+ * auto-fixable, agent-fix-providing, both, or neither.
+ *
+ * Implementations should return any JSON-serializable value (string,
+ * array, scalar, etc.) or null. Returning null is equivalent to not
+ * implementing the interface — the JSON output will fall back to
+ * `fix: null`.
+ */
+interface ProvidesAgentFix
+{
+    /**
+     * @return mixed JSON-serializable fix data, or null
+     */
+    public function agentFix(Violation $violation): mixed;
+}

--- a/src/Rules/WrongTabNamespaceRule.php
+++ b/src/Rules/WrongTabNamespaceRule.php
@@ -14,7 +14,7 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Use_;
 
-class WrongTabNamespaceRule implements FixableRule
+class WrongTabNamespaceRule implements FixableRule, ProvidesAgentFix
 {
     use AddsImport;
     use CalculatesLineNumbers;
@@ -143,5 +143,18 @@ class WrongTabNamespaceRule implements FixableRule
         }
 
         return [];
+    }
+
+    public function agentFix(Violation $violation): mixed
+    {
+        return [
+            'instructions' => 'Update any `Tab` import or v3-style `Tabs\Tab::make()` call to the correct `Filament\Schemas\Components\Tabs\Tab` namespace.',
+            'next_steps' => [
+                'Replace any `use Filament\...\Tab;` import whose fully qualified name is not `Filament\Schemas\Components\Tabs\Tab` with the correct namespace.',
+                'Replace any `Tabs\Tab::make()` call with `Tab::make()` (the import will be added automatically).',
+                'Ensure the file has `use Filament\Schemas\Components\Tabs\Tab;` — if the rule emits a second "missing import" violation, that is the auto-added import statement.',
+            ],
+            'docs' => $this->filamentDocsUrl('schemas/tabs'),
+        ];
     }
 }

--- a/src/Support/RunContext.php
+++ b/src/Support/RunContext.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Filacheck\Support;
+
+/**
+ * Process-wide flags about how filacheck is being invoked.
+ *
+ * Used so override packages (e.g. FilaCheck-Pro) can signal "we're running
+ * inside an AI coding agent" to bin/filacheck without the free package
+ * gaining a dependency on agent-detection logic. The free CLI reads this
+ * flag to decide whether to force --fix mode (so CodeFixer applies all
+ * auto-fixable issues with byte precision before any structured reporter
+ * — like JsonReporter — emits output).
+ */
+final class RunContext
+{
+    private static bool $agentMode = false;
+
+    public static function markAgent(): void
+    {
+        self::$agentMode = true;
+    }
+
+    public static function isAgent(): bool
+    {
+        return self::$agentMode;
+    }
+
+    public static function reset(): void
+    {
+        self::$agentMode = false;
+    }
+}

--- a/src/Support/Violation.php
+++ b/src/Support/Violation.php
@@ -16,5 +16,7 @@ class Violation
         public ?int $endPos = null,
         public ?string $replacement = null,
         public bool $silent = false,
+        public ?string $fixCommand = null,
+        public ?string $fixCommandCwd = null,
     ) {}
 }

--- a/tests/Fixer/CodeFixerTest.php
+++ b/tests/Fixer/CodeFixerTest.php
@@ -270,6 +270,175 @@ it('handles multiple files', function () {
     expect(file_get_contents($file2))->toBe('<?php $b->live();');
 });
 
+function makeCommandFixture(string $tempDir): string
+{
+    $project = $tempDir.'/project-'.uniqid();
+    mkdir($project, 0755, true);
+    file_put_contents($project.'/artisan', "#!/usr/bin/env php\n<?php\n");
+
+    return $project;
+}
+
+it('runs a command-style fix and counts it as fixed', function () {
+    $project = makeCommandFixture($this->tempDir);
+    $marker = $this->tempDir.'/ran-'.uniqid();
+
+    $violations = [
+        new Violation(
+            level: 'warning',
+            message: 'needs scaffolding',
+            file: $project.'/some/blade.blade.php',
+            line: 1,
+            isFixable: true,
+            fixCommand: 'touch '.escapeshellarg($marker),
+            fixCommandCwd: $project,
+        ),
+    ];
+
+    $results = (new CodeFixer)->fix($violations);
+
+    expect($results['fixed'])->toBe(1);
+    expect($results['skipped'])->toBe(0);
+    expect($results['commands'])->toHaveCount(1);
+    expect($results['commands'][0]['status'])->toBe('ran');
+    expect($results['commands'][0]['violations'])->toBe(1);
+    expect(file_exists($marker))->toBeTrue();
+
+    @unlink($marker);
+    @unlink($project.'/artisan');
+    @rmdir($project);
+});
+
+it('does not execute command-style fixes during dry run', function () {
+    $project = makeCommandFixture($this->tempDir);
+    $marker = $this->tempDir.'/dryrun-'.uniqid();
+
+    $violations = [
+        new Violation(
+            level: 'warning',
+            message: 'needs scaffolding',
+            file: $project.'/some/blade.blade.php',
+            line: 1,
+            isFixable: true,
+            fixCommand: 'touch '.escapeshellarg($marker),
+            fixCommandCwd: $project,
+        ),
+    ];
+
+    $results = (new CodeFixer)->fix($violations, dryRun: true);
+
+    expect($results['commands'])->toHaveCount(1);
+    expect($results['commands'][0]['status'])->toBe('would-run');
+    expect($results['fixed'])->toBe(1);
+    expect(file_exists($marker))->toBeFalse();
+
+    @unlink($project.'/artisan');
+    @rmdir($project);
+});
+
+it('dedupes identical command-style fixes across multiple violations', function () {
+    $project = makeCommandFixture($this->tempDir);
+    $counter = $this->tempDir.'/counter-'.uniqid();
+
+    $cmd = 'sh -c '.escapeshellarg('printf x >> '.escapeshellarg($counter));
+
+    $violations = [
+        new Violation(
+            level: 'warning',
+            message: 'first',
+            file: $project.'/a.blade.php',
+            line: 1,
+            isFixable: true,
+            fixCommand: $cmd,
+            fixCommandCwd: $project,
+        ),
+        new Violation(
+            level: 'warning',
+            message: 'second',
+            file: $project.'/b.blade.php',
+            line: 1,
+            isFixable: true,
+            fixCommand: $cmd,
+            fixCommandCwd: $project,
+        ),
+        new Violation(
+            level: 'warning',
+            message: 'third',
+            file: $project.'/c.blade.php',
+            line: 1,
+            isFixable: true,
+            fixCommand: $cmd,
+            fixCommandCwd: $project,
+        ),
+    ];
+
+    $results = (new CodeFixer)->fix($violations);
+
+    expect($results['commands'])->toHaveCount(1);
+    expect($results['commands'][0]['violations'])->toBe(3);
+    expect($results['fixed'])->toBe(3);
+    expect(file_get_contents($counter))->toBe('x');
+
+    @unlink($counter);
+    @unlink($project.'/artisan');
+    @rmdir($project);
+});
+
+it('marks failed command-style fixes as skipped', function () {
+    $project = makeCommandFixture($this->tempDir);
+
+    $violations = [
+        new Violation(
+            level: 'warning',
+            message: 'needs scaffolding',
+            file: $project.'/blade.blade.php',
+            line: 1,
+            isFixable: true,
+            fixCommand: 'sh -c "exit 7"',
+            fixCommandCwd: $project,
+        ),
+    ];
+
+    $results = (new CodeFixer)->fix($violations);
+
+    expect($results['fixed'])->toBe(0);
+    expect($results['skipped'])->toBe(1);
+    expect($results['commands'])->toHaveCount(1);
+    expect($results['commands'][0]['status'])->toBe('failed');
+
+    @unlink($project.'/artisan');
+    @rmdir($project);
+});
+
+it('refuses to run command-style fixes when cwd has no artisan', function () {
+    $bare = $this->tempDir.'/bare-'.uniqid();
+    mkdir($bare, 0755, true);
+    $marker = $this->tempDir.'/refused-'.uniqid();
+
+    $violations = [
+        new Violation(
+            level: 'warning',
+            message: 'needs scaffolding',
+            file: $bare.'/blade.blade.php',
+            line: 1,
+            isFixable: true,
+            fixCommand: 'touch '.escapeshellarg($marker),
+            fixCommandCwd: $bare,
+        ),
+    ];
+
+    $results = (new CodeFixer)->fix($violations);
+
+    expect($results['fixed'])->toBe(0);
+    expect($results['skipped'])->toBe(1);
+    expect($results['commands'])->toHaveCount(1);
+    expect($results['commands'][0]['status'])->toBe('failed');
+    expect($results['commands'][0]['output'])->toContain('artisan');
+    expect(file_exists($marker))->toBeFalse();
+
+    @rmdir($bare);
+});
+
 it('returns fix results by file', function () {
     $file = $this->tempDir.'/test.php';
     file_put_contents($file, '<?php $input->reactive();');

--- a/tests/Rules/ProvidesAgentFixContractTest.php
+++ b/tests/Rules/ProvidesAgentFixContractTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use Filacheck\Rules\ActionInBulkActionGroupRule;
+use Filacheck\Rules\DeprecatedActionFormRule;
+use Filacheck\Rules\DeprecatedBulkActionsRule;
+use Filacheck\Rules\DeprecatedEmptyLabelRule;
+use Filacheck\Rules\DeprecatedFilterFormRule;
+use Filacheck\Rules\DeprecatedFormsGetRule;
+use Filacheck\Rules\DeprecatedFormsSetRule;
+use Filacheck\Rules\DeprecatedGetTableQueryRule;
+use Filacheck\Rules\DeprecatedImageColumnSizeRule;
+use Filacheck\Rules\DeprecatedMutateFormDataUsingRule;
+use Filacheck\Rules\DeprecatedPlaceholderRule;
+use Filacheck\Rules\DeprecatedReactiveRule;
+use Filacheck\Rules\DeprecatedTestMethodsRule;
+use Filacheck\Rules\DeprecatedUrlParametersRule;
+use Filacheck\Rules\DeprecatedViewPropertyRule;
+use Filacheck\Rules\ProvidesAgentFix;
+use Filacheck\Rules\WrongTabNamespaceRule;
+use Filacheck\Support\Violation;
+
+dataset('agent-fix rules', [
+    'ActionInBulkActionGroupRule' => [ActionInBulkActionGroupRule::class],
+    'DeprecatedActionFormRule' => [DeprecatedActionFormRule::class],
+    'DeprecatedBulkActionsRule' => [DeprecatedBulkActionsRule::class],
+    'DeprecatedEmptyLabelRule' => [DeprecatedEmptyLabelRule::class],
+    'DeprecatedFilterFormRule' => [DeprecatedFilterFormRule::class],
+    'DeprecatedFormsGetRule' => [DeprecatedFormsGetRule::class],
+    'DeprecatedFormsSetRule' => [DeprecatedFormsSetRule::class],
+    'DeprecatedGetTableQueryRule' => [DeprecatedGetTableQueryRule::class],
+    'DeprecatedImageColumnSizeRule' => [DeprecatedImageColumnSizeRule::class],
+    'DeprecatedMutateFormDataUsingRule' => [DeprecatedMutateFormDataUsingRule::class],
+    'DeprecatedPlaceholderRule' => [DeprecatedPlaceholderRule::class],
+    'DeprecatedReactiveRule' => [DeprecatedReactiveRule::class],
+    'DeprecatedTestMethodsRule' => [DeprecatedTestMethodsRule::class],
+    'DeprecatedUrlParametersRule' => [DeprecatedUrlParametersRule::class],
+    'DeprecatedViewPropertyRule' => [DeprecatedViewPropertyRule::class],
+    'WrongTabNamespaceRule' => [WrongTabNamespaceRule::class],
+]);
+
+it('implements ProvidesAgentFix and returns a JSON-serializable structured fix', function (string $ruleClass) {
+    $rule = new $ruleClass;
+
+    expect($rule)->toBeInstanceOf(ProvidesAgentFix::class);
+
+    $violation = new Violation(
+        level: 'warning',
+        message: 'The `assertFormSet()` method is deprecated.',
+        file: 'app/Filament/Resources/UserResource.php',
+        line: 42,
+        rule: $rule->name(),
+    );
+
+    $fix = $rule->agentFix($violation);
+
+    expect($fix)
+        ->toBeArray()
+        ->toHaveKeys(['instructions', 'next_steps', 'docs']);
+
+    expect($fix['instructions'])->toBeString()->not->toBeEmpty();
+    expect($fix['next_steps'])->toBeArray()->not->toBeEmpty();
+
+    foreach ($fix['next_steps'] as $step) {
+        expect($step)->toBeString()->not->toBeEmpty();
+    }
+
+    expect($fix['docs'])->toBeString()->toStartWith('https://filamentphp.com/');
+
+    expect(json_encode($fix))->toBeString()->not->toBeFalse();
+})->with('agent-fix rules');


### PR DESCRIPTION
This PR lays the groundwork for the upcoming **FilaCheck-Pro** structured-output mode (where an AI coding agent runs `filacheck` and consumes a single JSON document on stdout) and ships the free-package half of the contract end-to-end:

1. **Scaffolding** — a small set of new abstractions in the free package that Pro can plug into without the free package having any dependency on agent-detection logic.
2. **Rule data** — every rule under `src/Rules/` now returns a structured, agent-actionable fix payload (`instructions`, `next_steps`, `docs`) so agents get a concrete plan instead of having to parse the human `suggestion` string.

The default `vendor/bin/filacheck` run against a terminal is **byte-for-byte unchanged** — the new code paths are only exercised when Pro flips them on.

The work is split across two commits.

---

## Commit 1 — `Prep structured agent output for pro version`

Adds the abstractions Pro needs to inject a structured reporter at runtime, plus a command-execution path in `CodeFixer` so Pro rules can ship "run `php artisan make:filament-theme admin`"-style fixes the same way the existing text-replacement rules do.

### New files

| File | Purpose |
|---|---|
| `src/Rules/ProvidesAgentFix.php` | Optional rule extension. Rules that implement it return JSON-serializable fix data per violation. |
| `src/Reporting/ReporterInterface.php` | Common contract (`report` / `reportWithFixes`) so reporters are pluggable. |
| `src/Reporting/ReporterFactory.php` | Static registry that lets Pro `override(...)` the default reporter at runtime — e.g. swap in `JsonReporter` when an agent is detected. |
| `src/Support/RunContext.php` | Process-wide flag (`markAgent` / `isAgent`) Pro sets when it detects an AI agent. The free CLI reads this flag — no Pro dependency. |

### Modified files

- **`src/Rules/FixableRule.php`** — docblock now documents two flavours of fixable violation: the existing **text replacement** (byte-precise edit of the offending file) and the new **command execution** (run an external command from the project root).
- **`src/Support/Violation.php`** — adds two nullable fields:
  ```php
  public ?string $fixCommand = null,
  public ?string $fixCommandCwd = null,
  ```
- **`src/Fixer/CodeFixer.php`** — partitions violations into text-style and command-style at the start of `fix()`, and gains a `fixCommands()` path that:
  - dedupes by `(fixCommand, fixCommandCwd)` so the same `php artisan ...` only runs once per scan even when many Blade files trigger it,
  - refuses to execute when the resolved cwd lacks an `artisan` file (guard against a misconfigured rule passing the wrong base path),
  - supports `--dry-run` (marks status `would-run`),
  - uses `symfony/process` (now a hard dependency in `composer.json`),
  - returns a new `commands` key in the `fix()` result describing every command's status / output.
- **`bin/filacheck`** — three behavioural changes, all gated on `RunContext::isAgent()`:
  1. `$reporter = StandaloneReporter::new(...)` is replaced with `ReporterFactory::make(...)` so Pro can swap it out.
  2. When `RunContext::isAgent()` is true, `$fix` is forced to `true` so `CodeFixer` applies all auto-fixable issues with byte precision **before** any structured reporter emits output. This avoids handing the agent ambiguous search/replace strings for fixes the tool can already apply itself.
  3. Progress chatter ("Scanning: …") moves to `stderr` and is silenced entirely in agent mode so `stdout` stays clean for a single parseable JSON document.
- **`src/Reporting/ConsoleReporter.php`** + **`src/Reporting/StandaloneReporter.php`** — now `implements ReporterInterface`. Behaviour unchanged.
- **`composer.json`** — adds `symfony/process: ^6.0|^7.0|^8.0` for the command-execution path.
- **`resources/boost/guidelines/core.blade.php`** — new Boost guideline that tells Laravel Boost agents to run `vendor/bin/filacheck --fix` after touching anything under `app/Filament`.

### Worked example: `ProvidesAgentFix` interface

```php
namespace Filacheck\Rules;

use Filacheck\Support\Violation;

interface ProvidesAgentFix
{
    /**
     * @return mixed JSON-serializable fix data, or null
     */
    public function agentFix(Violation $violation): mixed;
}
```

### Worked example: `RunContext`

```php
final class RunContext
{
    private static bool $agentMode = false;

    public static function markAgent(): void { self::$agentMode = true; }
    public static function isAgent(): bool { return self::$agentMode; }
    public static function reset(): void { self::$agentMode = false; }
}
```

### Worked example: agent-mode forcing in `bin/filacheck`

```php
// In agent mode, force --fix so CodeFixer applies all auto-fixable issues
// with byte-precise positions before any structured reporter (e.g.
// JsonReporter) emits output. This avoids handing the agent ambiguous
// search/replace strings for fixes the tool can already apply itself.
if (RunContext::isAgent()) {
    $fix = true;
}
```

---

## Commit 2 — `Provide structured agent fix data on free rules`

Implements `ProvidesAgentFix` on **all 16 rules** in `src/Rules/` so the JSON output Pro emits for a free-rule violation gets a concrete fix payload instead of `fix: null`.

### Pattern

Every rule now `implements <existingInterface>, ProvidesAgentFix`, gains the `ResolvesFilamentDocsUrl` trait if it didn't already have it, and adds an `agentFix(Violation $violation): mixed` method that returns:

```php
[
    'instructions' => string,    // 1-sentence imperative directive
    'next_steps'   => string[],  // 2–5 concrete bullets, including edge cases
    'docs'         => string,    // filamentDocsUrl(...) link
]
```

This shape mirrors the convention already in use in `FilaCheck-Pro/src/Rules`, so Pro's `JsonReporter` consumes free-rule and pro-rule fix payloads through a single code path.

### Worked example: `DeprecatedReactiveRule`

```diff
-class DeprecatedReactiveRule implements FixableRule
+class DeprecatedReactiveRule implements FixableRule, ProvidesAgentFix
 {
     use CalculatesLineNumbers;
     use ResolvesFilamentDocsUrl;

     // …existing check() unchanged…

+    public function agentFix(Violation $violation): mixed
+    {
+        return [
+            'instructions' => 'Replace the deprecated `reactive()` modifier with `live()`.',
+            'next_steps' => [
+                'Rename `->reactive()` to `->live()` on the field.',
+                'If you need debounced updates, use `->live(debounce: 500)`. If you only want to react on blur, use `->live(onBlur: true)`.',
+            ],
+            'docs' => $this->filamentDocsUrl('forms/overview#the-basics-of-reactivity'),
+        ];
+    }
 }
```

### Rules updated

| # | Rule | Theme |
|---|---|---|
| 1 | `ActionInBulkActionGroupRule` | `Action::make()` inside `toolbarActions()` → `BulkAction::make()` |
| 2 | `DeprecatedActionFormRule` | action `->form([...])` → `->schema([...])` |
| 3 | `DeprecatedBulkActionsRule` | table `->bulkActions([...])` → `->toolbarActions([...])` |
| 4 | `DeprecatedEmptyLabelRule` | `->label('')` → `->hiddenLabel()` / `->iconButton()` |
| 5 | `DeprecatedFilterFormRule` | filter `->form([...])` → `->schema([...])` |
| 6 | `DeprecatedFormsGetRule` | `Filament\Forms\Get` → `Filament\Schemas\Components\Utilities\Get` |
| 7 | `DeprecatedFormsSetRule` | `Filament\Forms\Set` → `Filament\Schemas\Components\Utilities\Set` |
| 8 | `DeprecatedGetTableQueryRule` | `getTableQuery()` → `->query()` inside `table()` |
| 9 | `DeprecatedImageColumnSizeRule` | `ImageColumn::size()` → `->imageSize()` |
| 10 | `DeprecatedMutateFormDataUsingRule` | `mutateFormDataUsing()` → `mutateDataUsing()` |
| 11 | `DeprecatedPlaceholderRule` | `Placeholder::make()` → `TextEntry::make()->state(...)` |
| 12 | `DeprecatedReactiveRule` | `->reactive()` → `->live()` |
| 13 | `DeprecatedTestMethodsRule` | v3 testing helpers → v4 `TestAction::make(...)` wrappers |
| 14 | `DeprecatedUrlParametersRule` | renamed Livewire URL query keys |
| 15 | `DeprecatedViewPropertyRule` | `$view` → `protected string $view` |
| 16 | `WrongTabNamespaceRule` | `Filament\Tabs\Tab` → `Filament\Schemas\Components\Tabs\Tab` |

### New test: `tests/Rules/ProvidesAgentFixContractTest.php`

A single dataset-driven contract test covers all 16 rules:

```php
it('implements ProvidesAgentFix and returns a JSON-serializable structured fix', function (string $ruleClass) {
    $rule = new $ruleClass;

    expect($rule)->toBeInstanceOf(ProvidesAgentFix::class);

    $violation = new Violation(
        level: 'warning',
        message: 'The `assertFormSet()` method is deprecated.',
        file: 'app/Filament/Resources/UserResource.php',
        line: 42,
        rule: $rule->name(),
    );

    $fix = $rule->agentFix($violation);

    expect($fix)
        ->toBeArray()
        ->toHaveKeys(['instructions', 'next_steps', 'docs']);

    expect($fix['instructions'])->toBeString()->not->toBeEmpty();
    expect($fix['next_steps'])->toBeArray()->not->toBeEmpty();

    foreach ($fix['next_steps'] as $step) {
        expect($step)->toBeString()->not->toBeEmpty();
    }

    expect($fix['docs'])->toBeString()->toStartWith('https://filamentphp.com/');

    expect(json_encode($fix))->toBeString()->not->toBeFalse();
})->with('agent-fix rules');
```

The test asserts the **shape** of the payload (and that it round-trips through `json_encode`), not the exact wording — so future copy tweaks don't churn the suite.

---

## Backwards compatibility

- **Default CLI behaviour is unchanged.** With no Pro plugin loaded, `RunContext::isAgent()` is always `false`, so `bin/filacheck` still resolves `StandaloneReporter` from `ReporterFactory::make(...)`, still writes "Scanning: …" to the terminal, and still only runs `--fix` when the user passes the flag.
- **Rule contract is additive.** `ProvidesAgentFix` is an optional interface; nothing in the free package's reporter chain calls `agentFix()`. Rules that don't implement it will continue to emit `fix: null` once Pro's `JsonReporter` lands, exactly as today.
- **`Violation` constructor** picks up two new optional fields at the **end** of the parameter list, so existing positional callers are unaffected.
- **`composer.json`** gains `symfony/process`. This is a new hard dependency but matches the existing `symfony/console` constraint, so Laravel apps already satisfy it transitively.

## Test results

```
Tests:    256 passed (962 assertions)
Duration: 1.25s
```

That's the previous 240 tests plus 16 new contract tests (one per rule) — every existing test still passes, no fixture changes were needed.

## Example agent payload (post-Pro)

Once the matching Pro PR lands and an AI agent runs `vendor/bin/filacheck`, a single violation now serialises to JSON like:

```json
{
  "rule": "deprecated-reactive",
  "file": "app/Filament/Resources/UserResource.php",
  "line": 87,
  "message": "The `reactive()` method is deprecated.",
  "fix": {
    "instructions": "Replace the deprecated `reactive()` modifier with `live()`.",
    "next_steps": [
      "Rename `->reactive()` to `->live()` on the field.",
      "If you need debounced updates, use `->live(debounce: 500)`. If you only want to react on blur, use `->live(onBlur: true)`."
    ],
    "docs": "https://filamentphp.com/docs/4.x/forms/overview#the-basics-of-reactivity"
  }
}
```

instead of:

```json
{ "rule": "deprecated-reactive", "fix": null }
```