### PR TITLE
Scope ExtraPathRule scans to their owning rules

### DIFF
--- a/bin/filacheck
+++ b/bin/filacheck
@@ -190,75 +190,91 @@ if ($dirty) {
 
     // Build all scannable paths (main path + extra paths + blade dir)
     // Use realpath() to normalize paths (resolve symlinks) so they match
-    // the canonical paths returned by GitDirtyFiles
-    $scanPaths = [];
-
-    $resolvedPath = realpath($path);
-    if ($resolvedPath !== false) {
-        $scanPaths[] = $resolvedPath;
-    }
+    // the canonical paths returned by GitDirtyFiles. Extra paths track their
+    // owning rules so dirty files inside them are scanned only with the
+    // requesting rule(s).
+    $mainScanPath = realpath($path) ?: null;
 
     $extraPathRules = array_filter($scanner->getRules(), fn ($rule) => $rule instanceof ExtraPathRule);
+    $extraPathOwners = [];
     foreach ($extraPathRules as $rule) {
         foreach ($rule->extraScanPaths() as $extraPath) {
             $fullPath = realpath(getcwd().DIRECTORY_SEPARATOR.$extraPath);
             if ($fullPath !== false && is_dir($fullPath)) {
-                $scanPaths[] = $fullPath;
+                $extraPathOwners[$fullPath][] = $rule;
             }
         }
     }
 
     $hasBladeRules = ! empty(array_filter($scanner->getRules(), fn ($rule) => $rule instanceof BladeRule));
+    $bladeDir = null;
     if ($hasBladeRules) {
-        $bladeDir = realpath(getcwd().DIRECTORY_SEPARATOR.'resources'.DIRECTORY_SEPARATOR.'views'.DIRECTORY_SEPARATOR.'filament');
-        if ($bladeDir !== false) {
-            $scanPaths[] = $bladeDir;
+        $resolvedBladeDir = realpath(getcwd().DIRECTORY_SEPARATOR.'resources'.DIRECTORY_SEPARATOR.'views'.DIRECTORY_SEPARATOR.'filament');
+        if ($resolvedBladeDir !== false) {
+            $bladeDir = $resolvedBladeDir;
         }
     }
 
     $violations = [];
 
     foreach ($dirtyFiles as $file) {
-        // Only scan files that fall within one of our scan paths
+        // Decide which rules apply: full set when inside the main path,
+        // only the owning rules when inside an extra path. Files outside
+        // any scope (including blade files in $bladeDir) are handled
+        // separately below.
+        $rulesForFile = null;
         $inScope = false;
-        foreach ($scanPaths as $scanPath) {
-            if (str_starts_with($file, $scanPath)) {
-                $inScope = true;
-                break;
+
+        if ($mainScanPath !== null && str_starts_with($file, $mainScanPath)) {
+            $inScope = true;
+        } else {
+            foreach ($extraPathOwners as $owned => $owningRules) {
+                if (str_starts_with($file, $owned)) {
+                    $rulesForFile = $owningRules;
+                    $inScope = true;
+                    break;
+                }
             }
+        }
+
+        if (str_ends_with($file, '.blade.php')) {
+            if ($hasBladeRules && $bladeDir !== null && str_starts_with($file, $bladeDir)) {
+                $bladeViolations = $scanner->scanBladeFile($file, getcwd());
+                $violations = array_merge($violations, $bladeViolations);
+            }
+            continue;
         }
 
         if (! $inScope) {
             continue;
         }
 
-        if (str_ends_with($file, '.blade.php') && $hasBladeRules) {
-            $bladeViolations = $scanner->scanBladeFile($file, getcwd());
-            $violations = array_merge($violations, $bladeViolations);
-        } elseif (str_ends_with($file, '.php')) {
-            $fileViolations = $scanner->scan($file, getcwd());
+        if (str_ends_with($file, '.php')) {
+            $fileViolations = $scanner->scan($file, getcwd(), $rulesForFile);
             $violations = array_merge($violations, $fileViolations);
         }
     }
 } else {
     $violations = $scanner->scan($path, getcwd());
 
-    // Extra paths from rules (e.g., app/Models for enum rules)
+    // Extra paths from rules (e.g., tests/ for the deprecated-test-methods rule).
+    // Each extra path is scanned only with the rules that requested it, so that
+    // rules like deprecated-url-parameters do not mis-fire on test files.
     $extraPathRules = array_filter($scanner->getRules(), fn ($rule) => $rule instanceof ExtraPathRule);
 
     if (! empty($extraPathRules)) {
-        $extraPaths = [];
+        $extraPathOwners = [];
         foreach ($extraPathRules as $rule) {
             foreach ($rule->extraScanPaths() as $extraPath) {
-                $extraPaths[$extraPath] = true;
+                $extraPathOwners[$extraPath][] = $rule;
             }
         }
 
-        foreach (array_keys($extraPaths) as $extraPath) {
+        foreach ($extraPathOwners as $extraPath => $rulesForPath) {
             $fullPath = getcwd().DIRECTORY_SEPARATOR.$extraPath;
             // Skip if already covered by the main scan path
             if (is_dir($fullPath) && ! str_starts_with($fullPath, $path) && ! str_starts_with($path, $fullPath)) {
-                $extraViolations = $scanner->scan($fullPath, getcwd());
+                $extraViolations = $scanner->scan($fullPath, getcwd(), $rulesForPath);
                 $violations = array_merge($violations, $extraViolations);
             }
         }

--- a/src/Scanner/ResourceScanner.php
+++ b/src/Scanner/ResourceScanner.php
@@ -45,15 +45,17 @@ class ResourceScanner
     }
 
     /**
+     * @param  Rule[]|null  $rules  When provided, only these rules are applied to the scan
      * @return Violation[]
      */
-    public function scan(string $path, ?string $basePath = null): array
+    public function scan(string $path, ?string $basePath = null, ?array $rules = null): array
     {
         $violations = [];
         $files = $this->findPhpFiles($path);
+        $effectiveRules = $rules ?? $this->rules;
 
         foreach ($files as $file) {
-            $fileViolations = $this->scanFile($file, $basePath);
+            $fileViolations = $this->scanFile($file, $basePath, $effectiveRules);
             $violations = array_merge($violations, $fileViolations);
         }
 
@@ -180,9 +182,10 @@ class ResourceScanner
     }
 
     /**
+     * @param  Rule[]  $rules
      * @return Violation[]
      */
-    private function scanFile(SplFileInfo $file, ?string $basePath = null): array
+    private function scanFile(SplFileInfo $file, ?string $basePath, array $rules): array
     {
         $code = file_get_contents($file->getPathname());
         $filePath = $file->getPathname();
@@ -209,7 +212,6 @@ class ResourceScanner
         }
 
         $violations = [];
-        $rules = $this->rules;
 
         $traverser = new NodeTraverser;
         $traverser->addVisitor(new NameResolver);

--- a/tests/Scanner/ExtraPathRuleTest.php
+++ b/tests/Scanner/ExtraPathRuleTest.php
@@ -117,6 +117,49 @@ it('scans extra path directory and finds violations', function () {
     expect($extraViolations[0]->file)->toBe('Models/Order.php');
 });
 
+it('applies only the requesting rules when scan() is given a rule subset', function () {
+    $testsDir = $this->tempDir.'/tests';
+    mkdir($testsDir, 0755, true);
+
+    file_put_contents($testsDir.'/SomeTest.php', '<?php $input->reactive();');
+
+    $scanner = new ResourceScanner;
+    $reactiveRule = new DeprecatedReactiveRule;
+    $extraPathRule = createExtraPathRule(['tests']);
+
+    $scanner->addRule($reactiveRule);
+    $scanner->addRule($extraPathRule);
+
+    // With no rule subset, every rule applies — both rules match reactive().
+    $allRulesViolations = $scanner->scan($testsDir, $this->tempDir);
+    $ruleNames = array_map(fn ($v) => $v->rule, $allRulesViolations);
+    expect($ruleNames)->toContain('deprecated-reactive');
+    expect($ruleNames)->toContain('test-extra-path-rule');
+
+    // Scoped to the extra-path rule only: deprecated-reactive does not fire.
+    $scopedViolations = $scanner->scan($testsDir, $this->tempDir, [$extraPathRule]);
+    $scopedRuleNames = array_map(fn ($v) => $v->rule, $scopedViolations);
+    expect($scopedRuleNames)->not->toContain('deprecated-reactive');
+    expect($scopedRuleNames)->toContain('test-extra-path-rule');
+});
+
+it('still runs the owning rule when scan() is scoped to it', function () {
+    $testsDir = $this->tempDir.'/tests';
+    mkdir($testsDir, 0755, true);
+
+    file_put_contents($testsDir.'/SomeTest.php', '<?php $input->reactive();');
+
+    $scanner = new ResourceScanner;
+    $extraPathRule = createExtraPathRule(['tests']);
+    $scanner->addRule(new DeprecatedReactiveRule);
+    $scanner->addRule($extraPathRule);
+
+    $violations = $scanner->scan($testsDir, $this->tempDir, [$extraPathRule]);
+
+    expect($violations)->toHaveCount(1);
+    expect($violations[0]->rule)->toBe('test-extra-path-rule');
+});
+
 it('skips extra path when already covered by main scan path', function () {
     $mainPath = $this->tempDir.'/app';
     $extraPath = $this->tempDir.'/app/Models';


### PR DESCRIPTION
# Scope extra-path scans to their owning rules

Fixes #41.

## Problem

`ExtraPathRule::extraScanPaths()` lets a rule register additional directories
to scan (today only `DeprecatedTestMethodsRule` uses it, for `tests/` and
`test/`). The CLI was then handing those directories to the scanner with the
**full** rule set, so every rule ran on every test file.

That caused the false positives reported in #41: `DeprecatedUrlParametersRule`
rewrote Livewire wire-property names like `tableFilters` / `tableSearch` inside
Pest tests, breaking the suite at runtime because Filament's real Livewire
properties are still `$tableFilters` / `$tableSearch`.

Same bug existed in the `--dirty` branch — dirty test files were scanned with
every rule.

## Fix

Each extra path is now scanned only with the rule(s) that requested it.

- `ResourceScanner::scan()` accepts an optional `?array $rules`; when set,
  only those rules run for that pass. Default behavior is unchanged.
- `bin/filacheck` builds a `path => Rule[]` map from
  `ExtraPathRule::extraScanPaths()` and calls `scan()` with each path's owning
  rules. So `tests/` runs only `DeprecatedTestMethodsRule`; the rest of the
  rules never see test files.
- `--dirty` flow uses the same map: a dirty file inside the main path keeps
  the full rule set, a dirty file inside an extra path gets only its owning
  rule(s).

No rule files were modified — the `ExtraPathRule` contract is unchanged.