### PR TITLE
Skip table filters in deprecated-empty-label rule

### DIFF
--- a/src/Rules/DeprecatedEmptyLabelRule.php
+++ b/src/Rules/DeprecatedEmptyLabelRule.php
@@ -60,8 +60,8 @@ class DeprecatedEmptyLabelRule implements FixableRule, ProvidesAgentFix
             return [];
         }
 
-        // Skip Table Columns - they don't have hiddenLabel() method
-        if ($this->isTableColumn($node, $context)) {
+        // Skip Table Columns and Filters - they don't have hiddenLabel() method
+        if ($this->isTableColumn($node, $context) || $this->isFilter($node, $context)) {
             return [];
         }
 
@@ -131,6 +131,22 @@ class DeprecatedEmptyLabelRule implements FixableRule, ProvidesAgentFix
         $shortName = $this->classBasename($rootClass);
 
         return str_ends_with($shortName, 'Column');
+    }
+
+    /**
+     * Check if the method chain originates from a Filter class.
+     */
+    private function isFilter(MethodCall $node, Context $context): bool
+    {
+        $rootClass = $this->getRootClassName($node, $context);
+
+        if ($rootClass === null) {
+            return false;
+        }
+
+        $shortName = $this->classBasename($rootClass);
+
+        return str_ends_with($shortName, 'Filter');
     }
 
     /**

--- a/tests/Rules/DeprecatedEmptyLabelRuleTest.php
+++ b/tests/Rules/DeprecatedEmptyLabelRuleTest.php
@@ -343,3 +343,69 @@ PHP;
     $this->assertViolationCount(1, $violations);
     expect($violations[0]->suggestion)->toContain('hiddenLabel()');
 });
+
+it('skips SelectFilter with empty label', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Tables\Filters\SelectFilter;
+
+class TestResource
+{
+    public function table(): array
+    {
+        return [
+            SelectFilter::make('status')->label(''),
+        ];
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new DeprecatedEmptyLabelRule, $code);
+
+    $this->assertNoViolations($violations);
+});
+
+it('skips TernaryFilter with empty label', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Tables\Filters\TernaryFilter;
+
+class TestResource
+{
+    public function table(): array
+    {
+        return [
+            TernaryFilter::make('active')->label(''),
+        ];
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new DeprecatedEmptyLabelRule, $code);
+
+    $this->assertNoViolations($violations);
+});
+
+it('skips $this->label(\'\') in a class extending a Filter', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Tables\Filters\SelectFilter;
+
+class StatusFilter extends SelectFilter
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->label('');
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new DeprecatedEmptyLabelRule, $code);
+
+    $this->assertNoViolations($violations);
+});


### PR DESCRIPTION
Extends the existing skip logic in `DeprecatedEmptyLabelRule` to also ignore
Filament table filters (`SelectFilter`, `TernaryFilter`, `TextInputFilter`, etc.).

Filters, like table columns, do not expose a `hiddenLabel()` method, so flagging
`->label('')` on them and suggesting `->hiddenLabel()` would produce an invalid fix.

## Changes

- `DeprecatedEmptyLabelRule`: added `isFilter()` guard (same pattern as the existing
  `isTableColumn()` guard) and combined both checks into a single early return.
- `DeprecatedEmptyLabelRuleTest`: added three new cases covering `SelectFilter`,
  `TernaryFilter`, and a custom class extending a filter via `$this->label('')`.

PS: Adding exclusions one by one by class name suffix could get a bit tricky, IMHO:
it might be worth exploring an alternative approach, like `class_uses_recursive()`.