### PR TITLE
New `deprecated-image-editor-aspect-ratios` rule

### DIFF
--- a/config/filacheck.php
+++ b/config/filacheck.php
@@ -51,6 +51,10 @@ return [
         'enabled' => true,
     ],
 
+    'deprecated-image-editor-aspect-ratios' => [
+        'enabled' => true,
+    ],
+
     'deprecated-view-property' => [
         'enabled' => true,
     ],

--- a/src/FilacheckServiceProvider.php
+++ b/src/FilacheckServiceProvider.php
@@ -11,6 +11,7 @@ use Filacheck\Rules\DeprecatedFormsGetRule;
 use Filacheck\Rules\DeprecatedFormsSetRule;
 use Filacheck\Rules\DeprecatedGetTableQueryRule;
 use Filacheck\Rules\DeprecatedImageColumnSizeRule;
+use Filacheck\Rules\DeprecatedImageEditorAspectRatiosRule;
 use Filacheck\Rules\DeprecatedMutateFormDataUsingRule;
 use Filacheck\Rules\DeprecatedPlaceholderRule;
 use Filacheck\Rules\DeprecatedReactiveRule;
@@ -76,6 +77,7 @@ class FilacheckServiceProvider extends ServiceProvider
             DeprecatedFormsGetRule::class,
             DeprecatedFormsSetRule::class,
             DeprecatedImageColumnSizeRule::class,
+            DeprecatedImageEditorAspectRatiosRule::class,
             DeprecatedViewPropertyRule::class,
             ActionInBulkActionGroupRule::class,
             DeprecatedBulkActionsRule::class,

--- a/src/Rules/DeprecatedImageEditorAspectRatiosRule.php
+++ b/src/Rules/DeprecatedImageEditorAspectRatiosRule.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Filacheck\Rules;
+
+use Filacheck\Enums\RuleCategory;
+use Filacheck\Rules\Concerns\CalculatesLineNumbers;
+use Filacheck\Rules\Concerns\ResolvesFilamentDocsUrl;
+use Filacheck\Support\Context;
+use Filacheck\Support\Violation;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+
+class DeprecatedImageEditorAspectRatiosRule implements FixableRule, ProvidesAgentFix
+{
+    use CalculatesLineNumbers;
+    use ResolvesFilamentDocsUrl;
+
+    public function name(): string
+    {
+        return 'deprecated-image-editor-aspect-ratios';
+    }
+
+    public function category(): RuleCategory
+    {
+        return RuleCategory::Deprecated;
+    }
+
+    public function check(Node $node, Context $context): array
+    {
+        if (! $node instanceof MethodCall) {
+            return [];
+        }
+
+        if (! $node->name instanceof Identifier) {
+            return [];
+        }
+
+        if ($node->name->name !== 'imageEditorAspectRatios') {
+            return [];
+        }
+
+        if (! $this->isFileUploadContext($node, $context)) {
+            return [];
+        }
+
+        $nameNode = $node->name;
+        $startPos = $nameNode->getStartFilePos();
+        $endPos = $nameNode->getEndFilePos() + 1;
+
+        return [
+            new Violation(
+                level: 'warning',
+                message: 'The `imageEditorAspectRatios()` method is deprecated on FileUpload.',
+                file: $context->file,
+                line: $this->getLineFromPosition($context->code, $startPos),
+                suggestion: 'Use `imageEditorAspectRatioOptions()` instead. See: '.$this->filamentDocsUrl('forms/file-upload#allowing-users-to-crop-images-to-aspect-ratios'),
+                isFixable: true,
+                startPos: $startPos,
+                endPos: $endPos,
+                replacement: 'imageEditorAspectRatioOptions',
+            ),
+        ];
+    }
+
+    public function agentFix(Violation $violation): mixed
+    {
+        return [
+            'instructions' => 'Rename the deprecated `imageEditorAspectRatios()` method on `FileUpload` (and `SpatieMediaLibraryFileUpload`) to `imageEditorAspectRatioOptions()`.',
+            'next_steps' => [
+                'Replace `->imageEditorAspectRatios(...)` with `->imageEditorAspectRatioOptions(...)`. Arguments are unchanged.',
+                'Apply this rename on `FileUpload` and `SpatieMediaLibraryFileUpload` chains only.',
+            ],
+            'docs' => $this->filamentDocsUrl('forms/file-upload#allowing-users-to-crop-images-to-aspect-ratios'),
+        ];
+    }
+
+    private function isFileUploadContext(MethodCall $node, Context $context): bool
+    {
+        $current = $node->var;
+
+        while ($current instanceof MethodCall) {
+            $current = $current->var;
+        }
+
+        if ($current instanceof StaticCall && $current->class instanceof Name) {
+            $parts = explode('\\', $current->class->toString());
+
+            return in_array(end($parts), ['FileUpload', 'SpatieMediaLibraryFileUpload'], true);
+        }
+
+        if ($current instanceof Variable && $current->name === 'this') {
+            return $this->isInsideFileUploadClass($context);
+        }
+
+        return false;
+    }
+
+    private function isInsideFileUploadClass(Context $context): bool
+    {
+        if (! preg_match('/class\s+\w+\s+extends\s+(\w+)/', $context->code, $matches)) {
+            return false;
+        }
+
+        return in_array($matches[1], ['FileUpload', 'SpatieMediaLibraryFileUpload'], true);
+    }
+}

--- a/tests/Rules/DeprecatedImageEditorAspectRatiosRuleTest.php
+++ b/tests/Rules/DeprecatedImageEditorAspectRatiosRuleTest.php
@@ -1,0 +1,230 @@
+<?php
+
+use Filacheck\Rules\DeprecatedImageEditorAspectRatiosRule;
+
+it('detects imageEditorAspectRatios on FileUpload', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Forms\Components\FileUpload;
+
+class TestResource
+{
+    public function form(): array
+    {
+        return [
+            FileUpload::make('image')
+                ->image()
+                ->imageEditor()
+                ->imageEditorAspectRatios(['16:9', '4:3']),
+        ];
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new DeprecatedImageEditorAspectRatiosRule, $code);
+
+    $this->assertViolationCount(1, $violations);
+    $this->assertViolationContains('imageEditorAspectRatios()', $violations);
+});
+
+it('detects imageEditorAspectRatios on SpatieMediaLibraryFileUpload', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
+
+class TestResource
+{
+    public function form(): array
+    {
+        return [
+            SpatieMediaLibraryFileUpload::make('media')
+                ->image()
+                ->imageEditor()
+                ->imageEditorAspectRatios(['16:9']),
+        ];
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new DeprecatedImageEditorAspectRatiosRule, $code);
+
+    $this->assertViolationCount(1, $violations);
+    $this->assertViolationContains('imageEditorAspectRatios()', $violations);
+});
+
+it('passes when imageEditorAspectRatioOptions is used', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Forms\Components\FileUpload;
+
+class TestResource
+{
+    public function form(): array
+    {
+        return [
+            FileUpload::make('image')
+                ->image()
+                ->imageEditor()
+                ->imageEditorAspectRatioOptions(['16:9', '4:3']),
+        ];
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new DeprecatedImageEditorAspectRatiosRule, $code);
+
+    $this->assertNoViolations($violations);
+});
+
+it('marks violations as fixable', function () {
+    $code = <<<'PHP'
+<?php
+
+class TestResource
+{
+    public function form(): array
+    {
+        return [
+            FileUpload::make('image')->imageEditorAspectRatios(['16:9']),
+        ];
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new DeprecatedImageEditorAspectRatiosRule, $code);
+
+    $this->assertViolationIsFixable($violations);
+});
+
+it('fixes imageEditorAspectRatios to imageEditorAspectRatioOptions', function () {
+    $code = <<<'PHP'
+<?php
+
+class TestResource
+{
+    public function form(): array
+    {
+        return [
+            FileUpload::make('image')->imageEditorAspectRatios(['16:9', '4:3']),
+        ];
+    }
+}
+PHP;
+
+    $fixedCode = $this->scanAndFix(new DeprecatedImageEditorAspectRatiosRule, $code);
+
+    expect($fixedCode)->toContain("->imageEditorAspectRatioOptions(['16:9', '4:3'])");
+    expect($fixedCode)->not->toContain('->imageEditorAspectRatios(');
+});
+
+it('does not flag imageEditorAspectRatios on unrelated components', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Forms\Components\TextInput;
+
+class TestResource
+{
+    public function form(): array
+    {
+        return [
+            TextInput::make('whatever')->imageEditorAspectRatios(['16:9']),
+        ];
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new DeprecatedImageEditorAspectRatiosRule, $code);
+
+    $this->assertNoViolations($violations);
+});
+
+it('detects $this->imageEditorAspectRatios() in a class extending FileUpload', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Forms\Components\FileUpload;
+
+class AvatarUpload extends FileUpload
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->image()
+            ->imageEditor()
+            ->imageEditorAspectRatios(['1:1']);
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new DeprecatedImageEditorAspectRatiosRule, $code);
+
+    $this->assertViolationCount(1, $violations);
+    $this->assertViolationContains('imageEditorAspectRatios()', $violations);
+});
+
+it('detects $this->imageEditorAspectRatios() in a class extending SpatieMediaLibraryFileUpload', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
+
+class MediaUpload extends SpatieMediaLibraryFileUpload
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->imageEditorAspectRatios(['16:9']);
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new DeprecatedImageEditorAspectRatiosRule, $code);
+
+    $this->assertViolationCount(1, $violations);
+});
+
+it('ignores $this->imageEditorAspectRatios() in a class that does not extend FileUpload', function () {
+    $code = <<<'PHP'
+<?php
+
+class SomeComponent extends Component
+{
+    protected function setUp(): void
+    {
+        $this->imageEditorAspectRatios(['16:9']);
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new DeprecatedImageEditorAspectRatiosRule, $code);
+
+    $this->assertNoViolations($violations);
+});
+
+it('fixes multiple imageEditorAspectRatios usages', function () {
+    $code = <<<'PHP'
+<?php
+
+class TestResource
+{
+    public function form(): array
+    {
+        return [
+            FileUpload::make('avatar')->imageEditorAspectRatios(['1:1']),
+            FileUpload::make('banner')->imageEditorAspectRatios(['16:9']),
+        ];
+    }
+}
+PHP;
+
+    $fixedCode = $this->scanAndFix(new DeprecatedImageEditorAspectRatiosRule, $code);
+
+    expect(substr_count($fixedCode, '->imageEditorAspectRatioOptions('))->toBe(2);
+    expect($fixedCode)->not->toContain('->imageEditorAspectRatios(');
+});

--- a/tests/Rules/ProvidesAgentFixContractTest.php
+++ b/tests/Rules/ProvidesAgentFixContractTest.php
@@ -9,6 +9,7 @@ use Filacheck\Rules\DeprecatedFormsGetRule;
 use Filacheck\Rules\DeprecatedFormsSetRule;
 use Filacheck\Rules\DeprecatedGetTableQueryRule;
 use Filacheck\Rules\DeprecatedImageColumnSizeRule;
+use Filacheck\Rules\DeprecatedImageEditorAspectRatiosRule;
 use Filacheck\Rules\DeprecatedMutateFormDataUsingRule;
 use Filacheck\Rules\DeprecatedPlaceholderRule;
 use Filacheck\Rules\DeprecatedReactiveRule;
@@ -29,6 +30,7 @@ dataset('agent-fix rules', [
     'DeprecatedFormsSetRule' => [DeprecatedFormsSetRule::class],
     'DeprecatedGetTableQueryRule' => [DeprecatedGetTableQueryRule::class],
     'DeprecatedImageColumnSizeRule' => [DeprecatedImageColumnSizeRule::class],
+    'DeprecatedImageEditorAspectRatiosRule' => [DeprecatedImageEditorAspectRatiosRule::class],
     'DeprecatedMutateFormDataUsingRule' => [DeprecatedMutateFormDataUsingRule::class],
     'DeprecatedPlaceholderRule' => [DeprecatedPlaceholderRule::class],
     'DeprecatedReactiveRule' => [DeprecatedReactiveRule::class],

--- a/tests/Support/RuleRegistryTest.php
+++ b/tests/Support/RuleRegistryTest.php
@@ -69,6 +69,7 @@ it('registers all rules from FilacheckServiceProvider', function () {
             \Filacheck\Rules\DeprecatedFormsGetRule::class,
             \Filacheck\Rules\DeprecatedFormsSetRule::class,
             \Filacheck\Rules\DeprecatedImageColumnSizeRule::class,
+            \Filacheck\Rules\DeprecatedImageEditorAspectRatiosRule::class,
             \Filacheck\Rules\DeprecatedViewPropertyRule::class,
             \Filacheck\Rules\ActionInBulkActionGroupRule::class,
             \Filacheck\Rules\DeprecatedBulkActionsRule::class,


### PR DESCRIPTION
Adds a new `deprecated-image-editor-aspect-ratios` rule that flags `imageEditorAspectRatios()` on `FileUpload` and `SpatieMediaLibraryFileUpload` (which extends `FileUpload`). Filament has renamed this method to `imageEditorAspectRatioOptions()`, and the rule provides an auto-fix that performs the rename.

## What's included

- **New rule:** `src/Rules/DeprecatedImageEditorAspectRatiosRule.php`
  - Category: `Deprecated`, level: `warning`
  - Detects `->imageEditorAspectRatios(...)` only on chains rooted in `FileUpload::make(...)` or `SpatieMediaLibraryFileUpload::make(...)`
  - Also detects `$this->imageEditorAspectRatios(...)` inside classes that extend `FileUpload` or `SpatieMediaLibraryFileUpload`
  - Ignores the method on unrelated components, so chains rooted elsewhere are left alone
  - Implements `FixableRule` (rename to `imageEditorAspectRatioOptions`) and `ProvidesAgentFix` (structured instructions for AI agents)
  - Suggestion links to `https://filamentphp.com/docs/{version}.x/forms/file-upload#allowing-users-to-crop-images-to-aspect-ratios`

- **Tests:** `tests/Rules/DeprecatedImageEditorAspectRatiosRuleTest.php` — 10 cases covering detection on both components, the `$this->` subclass paths, the unrelated-component guard, the "already migrated" passing case, single + multi-occurrence fixes, and the fixable flag.

- **Registration:**
  - Added to `FilacheckServiceProvider::rules()`
  - Added enable flag to `config/filacheck.php` (`deprecated-image-editor-aspect-ratios.enabled`, default `true`)
  - Added to the hardcoded rule lists in `tests/Support/RuleRegistryTest.php` and `tests/Rules/ProvidesAgentFixContractTest.php`