### PR TITLE
Add Sail compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,8 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.2, 8.3, 8.4, 8.5]
-        laravel: [11.*, 12.*, 13.*]
+        laravel: [12.*, 13.*]
         include:
-          - laravel: 11.*
-            testbench: ^9.0
           - laravel: 12.*
             testbench: ^10.0
           - laravel: 13.*
@@ -25,8 +23,6 @@ jobs:
         exclude:
           - laravel: 13.*
             php: 8.2
-          - laravel: 11.*
-            php: 8.5
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     },
     "require-dev": {
         "pestphp/pest": "^3.0|^4.0",
-        "orchestra/testbench": "^9.0|^10.0"
+        "orchestra/testbench": "^9.0|^10.0",
+        "laravel/boost": "^2.0"
     },
     "bin": ["bin/filacheck"],
     "autoload": {

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -1,3 +1,6 @@
+@php
+/** @var \Laravel\Boost\Install\GuidelineAssist $assist */
+@endphp
 ## laraveldaily/filacheck
 
 - After you have created/modified any files in `app/Filament` folder, you must run `{{ $assist->binCommand('filacheck --fix') }}`, to ensure there is no deprecated Filament code. Reported not fixed issues MUST be fixed before continuing.

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -1,3 +1,3 @@
 ## laraveldaily/filacheck
 
-- After you have created/modified any files in `app/Filament` folder, you must run `vendor/bin/filacheck --fix`, to ensure there is no deprecated Filament code. Reported not fixed issues MUST be fixed before continuing.
+- After you have created/modified any files in `app/Filament` folder, you must run `{{ $assist->binCommand('filacheck --fix') }}`, to ensure there is no deprecated Filament code. Reported not fixed issues MUST be fixed before continuing.

--- a/tests/Boost/BoostTestCase.php
+++ b/tests/Boost/BoostTestCase.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Filacheck\Tests\Boost;
+
+use Illuminate\Support\Facades\Blade;
+use Laravel\Boost\BoostServiceProvider;
+use Laravel\Boost\Install\GuidelineAssist;
+use Laravel\Boost\Install\GuidelineConfig;
+use Laravel\Roster\Roster;
+use Orchestra\Testbench\TestCase as OrchestraTestCase;
+
+class BoostTestCase extends OrchestraTestCase
+{
+    protected function getPackageProviders($app): array
+    {
+        return [BoostServiceProvider::class];
+    }
+
+    protected function defineEnvironment($app): void
+    {
+        $app['env'] = 'local';
+    }
+
+    protected function renderGuideline(bool $usesSail): string
+    {
+        $config = new GuidelineConfig;
+        $config->usesSail = $usesSail;
+
+        $roster = \Mockery::mock(Roster::class);
+        $assist = new GuidelineAssist($roster, $config);
+
+        $template = file_get_contents(
+            realpath(__DIR__.'/../../resources/boost/guidelines/core.blade.php')
+        );
+
+        return Blade::render($template, ['assist' => $assist]);
+    }
+}

--- a/tests/Boost/GuidelineTest.php
+++ b/tests/Boost/GuidelineTest.php
@@ -1,0 +1,13 @@
+<?php
+
+it('renders vendor/bin/filacheck when sail is disabled', function () {
+    $rendered = $this->renderGuideline(false);
+
+    expect($rendered)->toContain('vendor/bin/filacheck --fix');
+});
+
+it('renders vendor/bin/sail bin filacheck when sail is enabled', function () {
+    $rendered = $this->renderGuideline(true);
+
+    expect($rendered)->toContain('vendor/bin/sail bin filacheck --fix');
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Filacheck\Tests\Boost\BoostTestCase;
 use Filacheck\Tests\TestCase;
 
 uses(TestCase::class)->in('Rules');
@@ -7,3 +8,4 @@ uses(TestCase::class)->in('Fixer');
 uses(TestCase::class)->in('Support');
 uses(TestCase::class)->in('Reporting');
 uses(TestCase::class)->in('Scanner');
+uses(BoostTestCase::class)->in('Boost');


### PR DESCRIPTION
Hi, first of all, I want to clarify first that this PR uses a feature that is **not documented** in the [Boost docs](https://laravel.com/docs/13.x/boost#third-party-package-ai-guidelines), OpenCode with DeepSeek V4 Pro at max variant was used to discover how it was done and generate code & tests.

---

### TL;DR
Use `$assist->binCommand('filacheck --fix')` instead of hard-coded path to generate the correct path.

---

When using Laravel Sail, Boost instructs LLMs to use `vendor/bin/filacheck` which sometimes fails, sometimes corrects itself and uses `vendor/bin/sail bin filacheck`, this PR is to .

I noticed that Boost detects when running in Sail and it generates/updates the guidelines/skills based on that, so it got me thinking how it did that, so I forked the repo, added boost as a dependency and used OpenCode as stated. This is a translated message from the prompt I used in spanish.

> This is a package designed for Filament, a Laravel package that streamlines development.
> 
> I've included the laravel/boost package so you can view its code.
> 
> I understand that when setting up a Laravel project that uses Sail, there is a key named “sail” with a value of true in the boost.json file. When running the boost:install or boost:update command, it updates the guidelines/skills so that the commands to be run use vendor/bin/sail first, for example `vendor/bin/sail artisan list`.
> 
> Could you help me understand how that works, and if possible, implement that method here in this package so that @resources/boost/guidelines/core.blade.php is adjusted and the command is updated with the `vendor/bin/sail` prefix?

OpenCode response:

> I've thoroughly explored both packages. Here's the analysis and plan.
>
> **How laravel/boost handles sail prefixing**
>
> The mechanism is simple: when `boost.json` has `"sail": true`, `laravel/boost` injects a `GuidelineAssist `instance as `$assist` into **all** Blade templates during rendering. This object has methods that automatically prefix commands:
> | Method | Without Sail | With Sail |
> |---|---|---|
> | $assist->artisanCommand('migrate') | php artisan migrate | vendor/bin/sail artisan migrate |
> | $assist->composerCommand('install') | composer install | vendor/bin/sail composer install |
> | $assist->binCommand('pest') | vendor/bin/pest | vendor/bin/sail bin pest |
> | $assist->sailBinaryPath() | vendor/bin/sail | vendor/bin/sail |
>
> The key classes are:
> - vendor/laravel/boost/src/Install/GuidelineAssist.php — the $assist object with all prefixing logic
> - vendor/laravel/boost/src/Install/Sail.php — static helper that builds the prefixed strings
> - vendor/laravel/boost/src/Install/GuidelineConfig.php — holds the $usesSail boolean flag
>
> **The problem**
>
> FilaCheck's template hard-codes the command:
> `vendor/bin/filacheck --fix`
> It doesn't use $assist->binCommand(), so even when sail is enabled, the AI agent is told to run vendor/bin/filacheck outside the container — which would fail or not reflect sail state.
>
> **The fix**
>
> Single-line change in resources/boost/guidelines/core.blade.php:
> From:
> `vendor/bin/filacheck --fix`
> To:
> `{{ $assist->binCommand('filacheck --fix') }}`
> This will render as:
> - Without sail: `vendor/bin/filacheck --fix` (same as before)
> - With sail: `vendor/bin/sail bin filacheck --fix` (runs inside the container)
> No other changes needed — $assist is already injected into all templates by laravel/boost's RendersBladeGuidelines trait.

For the tests this was the prompt:

> Help me create tests to verify that it works in Laravel Sail

OpenCode response:

> Good news: `laravel/boost` has a test suite on GitHub that shows exactly how to test this, even though it isn't included in the vendor directory. I now have a clear idea of the approach.
> 
> Plan
> 
> We need to boot up a minimal Laravel app (using `orchestra/testbench`, which is already a development dependency) to render the Blade template with `$assist` injected, just as `boost:install` does.
> 
> 3 new/modified files:
> 
> 1. `tests/Boost/BoostTestCase.php` — Base TestCase that extends `Orchestra\Testbench\TestCase`, registers `BoostServiceProvider`, and exposes helpers to configure `GuidelineConfig` in the container.
> 
> 2. `tests/Boost/GuidelineTest.php` — Two tests:
> 
> - renders `vendor/bin/filacheck --fix` when sail is disabled — creates `GuidelineConfig` with `usesSail = false`, binds it to the container, renders `core.blade.php` via `Blade::render()` with `$assist` injected, and verifies that the output contains `vendor/bin/filacheck --fix`
> 
> - renders `vendor/bin/sail bin filacheck --fix` when sail is enabled — same flow but with `usesSail = true`, verifies that the output contains `vendor/bin/sail bin filacheck --fix`
> 
> 3. `tests/Pest.php` — Add `uses(BoostTestCase::class)->in('Boost')` so that Pest uses the correct TestCase in that directory.
> 
> The test renders the actual template as `boost:install` would, using the resolved `GuidelineAssist` from the container (mocking only `Roster` and the `discover()` method, as the official Boost tests do). This tests end-to-end behavior.
> 
> Does that sound good to you?