### PR TITLE
Fix direct toolbar action false positive

### DIFF
--- a/src/Rules/ActionInBulkActionGroupRule.php
+++ b/src/Rules/ActionInBulkActionGroupRule.php
@@ -44,7 +44,6 @@ class ActionInBulkActionGroupRule implements FixableRule, ProvidesAgentFix
 
         $violations = [];
         $nodeFinder = new NodeFinder;
-        $reported = [];
 
         $isActionMake = function (Node $n): bool {
             return $n instanceof StaticCall
@@ -54,7 +53,7 @@ class ActionInBulkActionGroupRule implements FixableRule, ProvidesAgentFix
                 && $n->name->name === 'make';
         };
 
-        // Check inside toolbarActions() for Action::make() in BulkActionGroup or directly
+        // Check inside toolbarActions() for Action::make() in BulkActionGroup.
         $toolbarActionsMethods = $nodeFinder->find($node, function (Node $n) {
             return $n instanceof MethodCall
                 && $n->name instanceof Identifier
@@ -80,39 +79,8 @@ class ActionInBulkActionGroupRule implements FixableRule, ProvidesAgentFix
                     $actionCalls = $nodeFinder->find($bulkActionGroup, $isActionMake);
 
                     foreach ($actionCalls as $actionCall) {
-                        $startPos = $actionCall->class->getStartFilePos();
-                        $reported[$startPos] = true;
-
                         $violations[] = $this->buildActionViolation($actionCall, $context);
                     }
-                }
-
-                // Exclude Action::make() inside ActionGroup::make() (not a BulkActionGroup)
-                $actionGroups = $nodeFinder->find($arg, function (Node $n) {
-                    return $n instanceof StaticCall
-                        && $n->class instanceof Name
-                        && class_basename($n->class->toString()) === 'ActionGroup'
-                        && $n->name instanceof Identifier
-                        && $n->name->name === 'make';
-                });
-
-                foreach ($actionGroups as $actionGroup) {
-                    foreach ($nodeFinder->find($actionGroup, $isActionMake) as $actionCall) {
-                        $reported[$actionCall->class->getStartFilePos()] = true;
-                    }
-                }
-
-                // Check Action::make() directly inside toolbarActions (not in BulkActionGroup or ActionGroup)
-                $actionCalls = $nodeFinder->find($arg, $isActionMake);
-
-                foreach ($actionCalls as $actionCall) {
-                    $startPos = $actionCall->class->getStartFilePos();
-
-                    if (isset($reported[$startPos])) {
-                        continue;
-                    }
-
-                    $violations[] = $this->buildActionViolation($actionCall, $context);
                 }
             }
         }
@@ -145,12 +113,11 @@ class ActionInBulkActionGroupRule implements FixableRule, ProvidesAgentFix
     public function agentFix(Violation $violation): mixed
     {
         return [
-            'instructions' => 'Replace `Action::make()` with `BulkAction::make()` whenever it appears inside `toolbarActions()` (directly or wrapped in a `BulkActionGroup`).',
+            'instructions' => 'Replace `Action::make()` with `BulkAction::make()` whenever it appears inside `BulkActionGroup::make()`.',
             'next_steps' => [
                 'Rename the `Action::make()` static call to `BulkAction::make()` — the rest of the chain stays the same.',
                 'Add `use Filament\Actions\BulkAction;` to the file (the rule emits a separate import violation for this when needed).',
-                'Do not rewrite `Action::make()` calls inside an `ActionGroup::make()` — those still belong to the per-row action group and are not bulk actions.',
-                'Single-record actions belong in `recordActions()`, not `toolbarActions()`. If the call was placed in the wrong slot, move it instead of changing its class.',
+                'Do not rewrite `Action::make()` calls outside `BulkActionGroup::make()`, including actions placed directly in `toolbarActions()`.',
             ],
             'docs' => $this->filamentDocsUrl('tables/actions#bulk-actions'),
         ];
@@ -164,7 +131,7 @@ class ActionInBulkActionGroupRule implements FixableRule, ProvidesAgentFix
 
         return new Violation(
             level: 'error',
-            message: '`Action::make()` is used inside `toolbarActions()`. Use `BulkAction::make()` instead.',
+            message: '`Action::make()` is used inside `BulkActionGroup::make()`. Use `BulkAction::make()` instead.',
             file: $context->file,
             line: $this->getLineFromPosition($context->code, $startPos),
             suggestion: 'Replace `Action::make()` with `BulkAction::make()`. See: ' . $this->filamentDocsUrl('tables/actions#bulk-actions'),

--- a/tests/Rules/ActionInBulkActionGroupRuleTest.php
+++ b/tests/Rules/ActionInBulkActionGroupRuleTest.php
@@ -311,59 +311,6 @@ PHP;
     expect(substr_count($fixedCode, 'use Filament\Actions\BulkAction;'))->toBe(1);
 });
 
-it('detects Action::make() directly inside toolbarActions without BulkActionGroup', function () {
-    $code = <<<'PHP'
-<?php
-
-use Filament\Tables\Actions\Action;
-use Filament\Tables\Table;
-
-class TestResource
-{
-    public function table(Table $table): Table
-    {
-        return $table
-            ->toolbarActions([
-                Action::make('approve')
-                    ->label('Approve Selected'),
-            ]);
-    }
-}
-PHP;
-
-    $violations = $this->scanCode(new ActionInBulkActionGroupRule, $code);
-
-    $this->assertViolationCount(1, $violations);
-    $this->assertViolationContains('Action::make()', $violations);
-});
-
-it('fixes Action::make() directly inside toolbarActions', function () {
-    $code = <<<'PHP'
-<?php
-
-use Filament\Tables\Actions\Action;
-use Filament\Tables\Table;
-
-class TestResource
-{
-    public function table(Table $table): Table
-    {
-        return $table
-            ->toolbarActions([
-                Action::make('approve')
-                    ->label('Approve Selected'),
-            ]);
-    }
-}
-PHP;
-
-    $fixedCode = $this->scanAndFix(new ActionInBulkActionGroupRule, $code);
-
-    expect($fixedCode)->toContain('BulkAction::make(\'approve\')');
-    expect($fixedCode)->not->toMatch('/[^k]Action::make/');
-    expect($fixedCode)->toContain('use Filament\Actions\BulkAction;');
-});
-
 it('does not flag Action::make() inside ActionGroup::make() within toolbarActions', function () {
     $code = <<<'PHP'
 <?php
@@ -419,4 +366,58 @@ PHP;
 
     $this->assertViolationCount(1, $violations);
     $this->assertViolationContains('Action::make()', $violations);
+});
+
+it('allows a direct toolbar Action that runs a custom query', function () {
+    $code = <<<'PHP'
+<?php
+
+use App\Models\Order;
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Table;
+
+class TestResource
+{
+    public function table(Table $table): Table
+    {
+        return $table
+            ->toolbarActions([
+                Action::make('processPending')
+                    ->action(fn () => Order::query()
+                        ->where('status', 'pending')
+                        ->update(['status' => 'processed'])),
+            ]);
+    }
+}
+PHP;
+
+    $violations = $this->scanCode(new ActionInBulkActionGroupRule, $code);
+
+    $this->assertNoViolations($violations);
+});
+
+it('leaves a direct toolbar Action unchanged when fixing', function () {
+    $code = <<<'PHP'
+<?php
+
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Table;
+
+class TestResource
+{
+    public function table(Table $table): Table
+    {
+        return $table
+            ->toolbarActions([
+                Action::make('approve')
+                    ->label('Approve Selected'),
+            ]);
+    }
+}
+PHP;
+
+    $fixedCode = $this->scanAndFix(new ActionInBulkActionGroupRule, $code);
+
+    expect($fixedCode)->toBe($code);
+    expect($fixedCode)->not->toContain('use Filament\Actions\BulkAction;');
 });


### PR DESCRIPTION
Fixes #46 by narrowing the `action-in-bulk-action-group` rule to report `Action::make()` only when it is nested inside `BulkActionGroup::make()`.

Regular actions placed directly in `toolbarActions()` are valid in Filament and are now left unchanged. The rule's violation message and structured agent-fix guidance have also been updated to reflect the narrower scope.