### PR TITLE
fix(deprecated-test-methods): --fix puts the record inside TestAction::make() for table action helpers

### DIFF
--- a/src/Rules/DeprecatedTestMethodsRule.php
+++ b/src/Rules/DeprecatedTestMethodsRule.php
@@ -9,6 +9,7 @@ use Filacheck\Rules\Concerns\ResolvesFilamentDocsUrl;
 use Filacheck\Support\Context;
 use Filacheck\Support\Violation;
 use PhpParser\Node;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Identifier;
 
@@ -21,14 +22,14 @@ class DeprecatedTestMethodsRule implements FixableRule, ExtraPathRule, ProvidesA
     use ResolvesFilamentDocsUrl;
 
     /**
-     * @var array<string, string|array{0: string, 1: string|array{0: string, 1: string}}>
+     * @var array<string, string|array{0: string, 1: string|array{0: string, 1: string}|array{0: string, 1: string, 2: string}}>
      */
     protected array $deprecatedMethods = [
         'setActionData' => ['fillForm()', 'fillForm'],
         'assertActionDataSet' => ['assertSchemaStateSet()', 'assertSchemaStateSet'],
         'assertHasActionErrors' => ['assertHasFormErrors()', 'assertHasFormErrors'],
         'assertHasNoActionErrors' => ['assertHasNoFormErrors()', 'assertHasNoFormErrors'],
-        'mountTableAction' => ['mountAction(TestAction::make(...)->table())', ['mountAction(TestAction::make(', ')->table())']],
+        'mountTableAction' => ['mountAction(TestAction::make(...)->table())', ['mountAction(TestAction::make(', ')->table(', '))']],
         'unmountTableAction' => ['unmountAction()', 'unmountAction'],
         'setTableActionData' => ['fillForm()', 'fillForm'],
         'assertTableActionDataSet' => ['assertSchemaStateSet()', 'assertSchemaStateSet'],
@@ -40,9 +41,9 @@ class DeprecatedTestMethodsRule implements FixableRule, ExtraPathRule, ProvidesA
         'assertTableActionHidden' => 'assertActionHidden(TestAction::make(...)->table($record))',
         'assertTableActionEnabled' => 'assertActionEnabled(TestAction::make(...)->table($record))',
         'assertTableActionDisabled' => 'assertActionDisabled(TestAction::make(...)->table($record))',
-        'assertTableActionMounted' => ['assertActionMounted(TestAction::make(...)->table())', ['assertActionMounted(TestAction::make(', ')->table())']],
+        'assertTableActionMounted' => ['assertActionMounted(TestAction::make(...)->table())', ['assertActionMounted(TestAction::make(', ')->table(', '))']],
         'assertTableActionNotMounted' => 'assertActionNotMounted(TestAction::make(...)->table(...))',
-        'assertTableActionHalted' => ['assertActionHalted(TestAction::make(...)->table())', ['assertActionHalted(TestAction::make(', ')->table())']],
+        'assertTableActionHalted' => ['assertActionHalted(TestAction::make(...)->table())', ['assertActionHalted(TestAction::make(', ')->table(', '))']],
         'assertHasTableActionErrors' => ['assertHasFormErrors()', 'assertHasFormErrors'],
         'assertHasNoTableActionErrors' => ['assertHasNoFormErrors()', 'assertHasNoFormErrors'],
         'mountTableBulkAction' => 'mountAction(TestAction::make(...)->table()->bulk())',
@@ -215,7 +216,7 @@ class DeprecatedTestMethodsRule implements FixableRule, ExtraPathRule, ProvidesA
     }
 
     /**
-     * @param  string|array{0: string, 1: string|array{0: string, 1: string}}  $deprecatedMethod
+     * @param  string|array{0: string, 1: string|array{0: string, 1: string}|array{0: string, 1: string, 2: string}}  $deprecatedMethod
      * @return array{startPos: int, endPos: int, replacement: string}|null
      */
     protected function getFix(MethodCall $node, string $code, string | array $deprecatedMethod): ?array
@@ -243,11 +244,77 @@ class DeprecatedTestMethodsRule implements FixableRule, ExtraPathRule, ProvidesA
             ];
         }
 
+        if (count($fix) === 2) {
+            return [
+                'startPos' => $node->name->getStartFilePos(),
+                'endPos' => $node->getEndFilePos() + 1,
+                'replacement' => $fix[0] . $args . $fix[1],
+            ];
+        }
+
+        $splitArguments = $this->splitFirstArgument($node, $code);
+
+        if ($splitArguments === null) {
+            return null;
+        }
+
         return [
             'startPos' => $node->name->getStartFilePos(),
             'endPos' => $node->getEndFilePos() + 1,
-            'replacement' => $fix[0] . $args . $fix[1],
+            'replacement' => $fix[0] . $splitArguments[0] . $fix[1] . $splitArguments[1] . $fix[2],
         ];
+    }
+
+    /**
+     * Split the call's arguments into the first argument and everything after it,
+     * using the AST for the boundary so that commas inside a later argument
+     * (`->mountTableAction('edit', $posts->firstWhere('slug', 'a'))`) do not split it.
+     *
+     * @return array{0: string, 1: string}|null
+     */
+    protected function splitFirstArgument(MethodCall $node, string $code): ?array
+    {
+        $arguments = $node->args;
+
+        foreach ($arguments as $argument) {
+            if (! $argument instanceof Arg) {
+                return null;
+            }
+        }
+
+        if ($arguments === []) {
+            return ['', ''];
+        }
+
+        $firstArgument = $arguments[0];
+        $firstArgumentSource = substr(
+            $code,
+            $firstArgument->getStartFilePos(),
+            $firstArgument->getEndFilePos() - $firstArgument->getStartFilePos() + 1,
+        );
+
+        if ($firstArgumentSource === false) {
+            return null;
+        }
+
+        if (count($arguments) === 1) {
+            return [$firstArgumentSource, ''];
+        }
+
+        $remainingArgumentsStart = $arguments[1]->getStartFilePos();
+        $remainingArgumentsEnd = $arguments[count($arguments) - 1]->getEndFilePos();
+
+        $remainingArgumentsSource = substr(
+            $code,
+            $remainingArgumentsStart,
+            $remainingArgumentsEnd - $remainingArgumentsStart + 1,
+        );
+
+        if ($remainingArgumentsSource === false) {
+            return null;
+        }
+
+        return [$firstArgumentSource, $remainingArgumentsSource];
     }
 
     protected function getArgumentsSource(MethodCall $node, string $code): ?string

--- a/tests/Rules/DeprecatedTestMethodsRuleTest.php
+++ b/tests/Rules/DeprecatedTestMethodsRuleTest.php
@@ -267,6 +267,30 @@ dataset('fixableDeprecatedTestMethods', [
         '->assertHasNoFormErrors()',
         false,
     ],
+    'mountTableAction with a record' => [
+        '->mountTableAction(\'edit\', $record)',
+        'Use `mountAction(TestAction::make(...)->table())` instead.',
+        '->mountAction(TestAction::make(\'edit\')->table($record))',
+        true,
+    ],
+    'assertTableActionMounted with a record' => [
+        '->assertTableActionMounted(\'edit\', $record)',
+        'Use `assertActionMounted(TestAction::make(...)->table())` instead.',
+        '->assertActionMounted(TestAction::make(\'edit\')->table($record))',
+        true,
+    ],
+    'assertTableActionHalted with a record' => [
+        '->assertTableActionHalted(\'edit\', $record)',
+        'Use `assertActionHalted(TestAction::make(...)->table())` instead.',
+        '->assertActionHalted(TestAction::make(\'edit\')->table($record))',
+        true,
+    ],
+    'mountTableAction with a record expression containing a comma' => [
+        '->mountTableAction(\'edit\', $posts->firstWhere(\'slug\', \'hello\'))',
+        'Use `mountAction(TestAction::make(...)->table())` instead.',
+        '->mountAction(TestAction::make(\'edit\')->table($posts->firstWhere(\'slug\', \'hello\')))',
+        true,
+    ],
 ]);
 
 dataset('nonFixableDeprecatedTestMethods', [


### PR DESCRIPTION
## The bug

`mountTableAction`, `assertTableActionMounted` and `assertTableActionHalted` map their auto-fix to a prefix/suffix string wrap placed around the **entire** argument list:

```php
'mountTableAction' => ['mountAction(TestAction::make(...)->table())', ['mountAction(TestAction::make(', ')->table())']],
```

That is only correct for the single-argument form. Given the two-argument form, `--fix` produces:

```php
// before
->mountTableAction('edit', $record)

// after --fix  ❌ record ends up inside make()
->mountAction(TestAction::make('edit', $record)->table())

// expected
->mountAction(TestAction::make('edit')->table($record))
```

The generated code parses, so `--fix` reports success and exits clean. The breakage only shows up when the suite runs, as a failure deep inside Filament's own `getDefaultTestingSchemaName()`, with nothing in the message pointing back at the rewrite. That makes it fairly costly to trace — we hit it on a 21-file migration and it took a full test run plus a bisect to attribute.

Found on v1.2.2, still present on `main`.

## The fix

The three affected mappings move to a three-part prefix/middle/suffix fix:

```php
['mountAction(TestAction::make(', ')->table(', '))']
```

The first argument goes into `make()`, everything after it into `table()`. Existing two-part mappings take an early return and are completely untouched.

The argument boundary comes from the AST (`$node->args` start/end file positions), not from splitting the raw source on commas. That matters for a record expression that itself contains a comma:

```php
->mountTableAction('edit', $posts->firstWhere('slug', 'hello'))
// → ->mountAction(TestAction::make('edit')->table($posts->firstWhere('slug', 'hello')))
```

A naive comma split would have produced `TestAction::make('edit')->table($posts->firstWhere('slug')` + garbage.

## Tests

Written test-first — all four failed against the current implementation before the fix, each for the expected reason (record inside `make()`).

Added to the `fixableDeprecatedTestMethods` dataset:

- `mountTableAction` with a record
- `assertTableActionMounted` with a record
- `assertTableActionHalted` with a record
- `mountTableAction` with a record expression containing a comma

The existing single-argument entries stay as-is and still pass, which is what pins the no-regression side.

## Verification

- `vendor/bin/pest tests/Rules/DeprecatedTestMethodsRuleTest.php` — **57 passed** (was 53; +4 new)
- `vendor/bin/pest` (full suite) — **276 passed, 2 failed**

The 2 failures are `tests/Boost/GuidelineTest.php` and are **pre-existing on `main`**, unrelated to this change — `GuidelineAssist::__construct()` now expects `Laravel\Roster\ProjectManager` but `BoostTestCase.php:30` passes a mocked `Roster`. I reproduced them identically on a clean checkout with this branch stashed (272 passed, same 2 failed). Not addressed here.

End-to-end against the real binary:

```php
// input
->mountTableAction('edit', $record)
->assertTableActionMounted('edit', $record)
->mountTableAction('create');

// after php bin/filacheck --fix
->mountAction(TestAction::make('edit')->table($record))
->assertActionMounted(TestAction::make('edit')->table($record))
->mountAction(TestAction::make('create')->table());
```

## Possibly out of scope

The same whole-argument-list wrap is used by the `assertFormFieldHidden` / `assertFormComponentExists` family, where the second v3 argument is a schema name rather than a record. Those look like they may have a related issue, but the correct v4 shape there is less obvious to me, so I've left them alone rather than guess.
